### PR TITLE
[codex] fix Reddit loader fallback strategy

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,7 @@
 - Keep CLI `--loader` composition coupled to CLI-local `LOADER_DEFS` (or inject registry explicitly) so test monkeypatching remains effective.
 - Keep `openai_web` on `firecrawl` only with `NO_FALLBACK`; do not append default fallback loaders for that route.
 - For local example runs, execute the user's exact command first and only add env overrides (for example `UV_CACHE_DIR`) after reproducing a concrete failure.
+- Reddit RSS fallback can return 403 when using browser-like request headers; fetch RSS with default httpx headers.
 
 ## TASTE
 

--- a/src/kabigon/loaders/reddit.py
+++ b/src/kabigon/loaders/reddit.py
@@ -1,10 +1,15 @@
 import logging
+from typing import Any
+from typing import cast
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
+from xml.etree import ElementTree as ET
 
+import httpx
 from playwright.async_api import TimeoutError
 from playwright.async_api import async_playwright
 
+from kabigon.domain.errors import LoaderContentError
 from kabigon.domain.errors import LoaderTimeoutError
 from kabigon.domain.loader import Loader
 
@@ -49,6 +54,151 @@ def convert_to_old_reddit(url: str) -> str:
     return str(urlunparse(parsed._replace(netloc="old.reddit.com")))
 
 
+def to_reddit_json_url(url: str) -> str:
+    """Normalize Reddit URL to a `www.reddit.com/.../.json` API URL."""
+    parsed = urlparse(url)
+    path = parsed.path.rstrip("/")
+    if not path.endswith(".json"):
+        path = f"{path}.json"
+    return str(urlunparse(parsed._replace(netloc="www.reddit.com", path=path, query="", fragment="")))
+
+
+def to_reddit_rss_url(url: str) -> str:
+    parsed = urlparse(url)
+    path = parsed.path.rstrip("/")
+    if not path.endswith(".rss"):
+        path = f"{path}/.rss"
+    return str(urlunparse(parsed._replace(netloc="www.reddit.com", path=path, query="", fragment="")))
+
+
+def _post_markdown(post: dict[str, Any]) -> str:
+    title = str(post.get("title") or "").strip()
+    author = str(post.get("author") or "unknown")
+    subreddit = str(post.get("subreddit") or "unknown")
+    score = post.get("score")
+    permalink = str(post.get("permalink") or "").strip()
+    permalink_url = f"https://www.reddit.com{permalink}" if permalink else ""
+    body = str(post.get("selftext") or "").strip()
+    external_url = str(post.get("url") or "").strip()
+
+    lines = [f"# {title or '[untitled]'}", "", f"- Author: u/{author}", f"- Subreddit: r/{subreddit}"]
+    if score is not None:
+        lines.append(f"- Score: {score}")
+    if permalink_url:
+        lines.append(f"- Permalink: {permalink_url}")
+    if body:
+        lines.extend(["", body])
+    elif external_url:
+        lines.extend(["", f"External URL: {external_url}"])
+    return "\n".join(lines)
+
+
+def _append_comments_markdown(lines: list[str], children: list[dict[str, Any]], depth: int = 0) -> None:
+    indent = "  " * depth
+    for child in children:
+        if child.get("kind") != "t1":
+            continue
+
+        data = child.get("data")
+        if not isinstance(data, dict):
+            continue
+
+        author = str(data.get("author") or "unknown")
+        score = data.get("score")
+        body = str(data.get("body") or "").strip()
+        header = f"{indent}- u/{author}"
+        if score is not None:
+            header += f" ({score})"
+        lines.append(header + ":")
+        if body:
+            lines.extend(f"{indent}  {body_line}" for body_line in body.splitlines())
+        else:
+            lines.append(f"{indent}  [no text]")
+
+        replies = data.get("replies")
+        if isinstance(replies, dict):
+            replies_data = replies.get("data")
+            if isinstance(replies_data, dict):
+                replies_children = replies_data.get("children")
+                if isinstance(replies_children, list):
+                    _append_comments_markdown(lines, replies_children, depth=depth + 1)
+
+
+def _children_from_listing(listing: object, api_url: str) -> list[dict[str, Any]]:
+    if not isinstance(listing, dict):
+        raise LoaderContentError("RedditLoader", api_url, "Invalid listing payload.")
+    listing_dict = cast(dict[str, Any], listing)
+    listing_data = listing_dict.get("data")
+    if not isinstance(listing_data, dict):
+        raise LoaderContentError("RedditLoader", api_url, "Invalid listing data payload.")
+    children = listing_data.get("children")
+    if not isinstance(children, list):
+        raise LoaderContentError("RedditLoader", api_url, "Invalid listing children payload.")
+    return [child for child in children if isinstance(child, dict)]
+
+
+def _extract_post(payload: object, api_url: str) -> dict[str, Any]:
+    if not isinstance(payload, list) or len(payload) < 1:
+        raise LoaderContentError("RedditLoader", api_url, "Unexpected Reddit JSON payload shape.")
+    post_children = _children_from_listing(payload[0], api_url)
+    if not post_children:
+        raise LoaderContentError("RedditLoader", api_url, "Post not found in Reddit JSON payload.")
+    post_data = post_children[0].get("data")
+    if not isinstance(post_data, dict):
+        raise LoaderContentError("RedditLoader", api_url, "Invalid post entry in Reddit JSON payload.")
+    return post_data
+
+
+def _extract_comment_children(payload: object, api_url: str) -> list[dict[str, Any]]:
+    if not isinstance(payload, list) or len(payload) < 2:
+        return []
+    return _children_from_listing(payload[1], api_url)
+
+
+def _atom_text(parent: ET.Element, tag: str) -> str:
+    node = parent.find(f"{{http://www.w3.org/2005/Atom}}{tag}")
+    return (node.text or "").strip() if node is not None else ""
+
+
+def _rss_to_markdown(xml_text: str, source_url: str) -> str:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        raise LoaderContentError(
+            "RedditLoader",
+            source_url,
+            f"Invalid RSS XML payload: {e}",
+        ) from e
+
+    feed_title = _atom_text(root, "title") or "Reddit Post"
+    lines = [f"# {feed_title}", "", f"- URL Source: {source_url}", "", "## Entries", ""]
+    entries = root.findall("{http://www.w3.org/2005/Atom}entry")
+    if not entries:
+        lines.append("(No entries)")
+        return "\n".join(lines).strip()
+
+    for entry in entries:
+        entry_title = _atom_text(entry, "title") or "[untitled]"
+        updated = _atom_text(entry, "updated")
+        author = ""
+        author_node = entry.find("{http://www.w3.org/2005/Atom}author")
+        if author_node is not None:
+            author = _atom_text(author_node, "name")
+        content_node = entry.find("{http://www.w3.org/2005/Atom}content")
+        content_html = (content_node.text or "").strip() if content_node is not None else ""
+        content_md = html_to_markdown(content_html).strip() if content_html else ""
+
+        lines.append(f"### {entry_title}")
+        if author:
+            lines.append(f"- Author: {author}")
+        if updated:
+            lines.append(f"- Updated: {updated}")
+        lines.append("")
+        lines.append(content_md or "(No content)")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
 class RedditLoader(Loader):
     """Loader for Reddit posts and comments.
 
@@ -62,6 +212,94 @@ class RedditLoader(Loader):
             timeout: Timeout in milliseconds for page loading (default: 30 seconds)
         """
         self.timeout = timeout
+
+    async def _load_via_json(self, url: str) -> str:
+        api_url = to_reddit_json_url(url)
+        timeout_seconds = self.timeout / 1000
+        headers = {
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=True) as client:
+                response = await client.get(api_url, headers=headers)
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.TimeoutException as e:
+            raise LoaderTimeoutError(
+                "RedditLoader",
+                api_url,
+                timeout_seconds,
+                "Reddit JSON endpoint timed out. Try increasing the timeout.",
+            ) from e
+        except (httpx.HTTPError, ValueError) as e:
+            raise LoaderContentError(
+                "RedditLoader",
+                api_url,
+                f"Reddit JSON request failed: {e}",
+                "Try again later or use the Playwright fallback path.",
+            ) from e
+
+        post_data = _extract_post(payload, api_url)
+        comment_children = _extract_comment_children(payload, api_url)
+
+        result_lines = [_post_markdown(post_data), "", "## Comments", ""]
+        if comment_children:
+            _append_comments_markdown(result_lines, comment_children)
+        else:
+            result_lines.append("(No comments)")
+        return "\n".join(result_lines).strip()
+
+    async def _load_via_rss(self, url: str) -> str:
+        rss_url = to_reddit_rss_url(url)
+        timeout_seconds = self.timeout / 1000
+        try:
+            async with httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=True) as client:
+                response = await client.get(rss_url)
+                response.raise_for_status()
+        except httpx.TimeoutException as e:
+            raise LoaderTimeoutError(
+                "RedditLoader",
+                rss_url,
+                timeout_seconds,
+                "Reddit RSS endpoint timed out. Try increasing the timeout.",
+            ) from e
+        except httpx.HTTPError as e:
+            raise LoaderContentError(
+                "RedditLoader",
+                rss_url,
+                f"Reddit RSS request failed: {e}",
+                "Try again later or use the Playwright fallback path.",
+            ) from e
+
+        return _rss_to_markdown(response.text, rss_url)
+
+    async def _load_via_old_reddit(self, url: str) -> str:
+        old_reddit_url = convert_to_old_reddit(url)
+        logger.debug("[RedditLoader] Converted to old Reddit: %s", old_reddit_url)
+
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=True)
+            context = await browser.new_context(user_agent=USER_AGENT)
+            page = await context.new_page()
+
+            try:
+                await page.goto(old_reddit_url, timeout=self.timeout, wait_until="networkidle")
+                logger.debug("[RedditLoader] Page loaded successfully via old Reddit")
+            except TimeoutError as e:
+                await browser.close()
+                logger.warning("[RedditLoader] Timeout after %ss: %s", self.timeout / 1000, old_reddit_url)
+                raise LoaderTimeoutError(
+                    "RedditLoader",
+                    old_reddit_url,
+                    self.timeout / 1000,
+                    "Reddit pages can be slow to load. Try increasing the timeout.",
+                ) from e
+
+            content = await page.content()
+            await browser.close()
+            return html_to_markdown(content)
 
     async def load(self, url: str) -> str:
         """Asynchronously load Reddit content from URL.
@@ -78,30 +316,22 @@ class RedditLoader(Loader):
         """
         logger.debug("[RedditLoader] Processing URL: %s", url)
         check_reddit_url(url)
-        url = convert_to_old_reddit(url)
-        logger.debug("[RedditLoader] Converted to old Reddit: %s", url)
-
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(headless=True)
-            context = await browser.new_context(user_agent=USER_AGENT)
-            page = await context.new_page()
-
+        try:
+            result = await self._load_via_json(url)
+        except (LoaderContentError, LoaderTimeoutError) as json_error:
+            logger.warning("[RedditLoader] JSON endpoint failed, trying RSS fallback: %s", json_error)
             try:
-                await page.goto(url, timeout=self.timeout, wait_until="networkidle")
-                logger.debug("[RedditLoader] Page loaded successfully")
-            except TimeoutError as e:
-                await browser.close()
-                logger.warning("[RedditLoader] Timeout after %ss: %s", self.timeout / 1000, url)
-                raise LoaderTimeoutError(
-                    "RedditLoader",
-                    url,
-                    self.timeout / 1000,
-                    "Reddit pages can be slow to load. Try increasing the timeout.",
-                ) from e
-
-            content = await page.content()
-            await browser.close()
-
-            result = html_to_markdown(content)
-            logger.debug("[RedditLoader] Successfully extracted content (%s chars)", len(result))
+                result = await self._load_via_rss(url)
+            except (LoaderContentError, LoaderTimeoutError) as rss_error:
+                logger.warning("[RedditLoader] RSS fallback failed, falling back to old Reddit: %s", rss_error)
+                result = await self._load_via_old_reddit(url)
+                logger.debug(
+                    "[RedditLoader] Successfully extracted content from old Reddit fallback (%s chars)",
+                    len(result),
+                )
+                return result
+            logger.debug("[RedditLoader] Successfully extracted content from RSS fallback (%s chars)", len(result))
+            return result
+        else:
+            logger.debug("[RedditLoader] Successfully extracted content from JSON endpoint (%s chars)", len(result))
             return result

--- a/tests/loaders/test_reddit.py
+++ b/tests/loaders/test_reddit.py
@@ -8,6 +8,52 @@ from kabigon.loaders.reddit import RedditLoader
 from kabigon.loaders.reddit import to_reddit_json_url
 from kabigon.loaders.reddit import to_reddit_rss_url
 
+RSS_XML = """
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Demo Feed</title>
+  <entry>
+    <title>Post title</title>
+    <author><name>alice</name></author>
+    <updated>2026-03-27T06:12:49+00:00</updated>
+    <content type="html">&lt;div&gt;&lt;p&gt;RSS content&lt;/p&gt;&lt;/div&gt;</content>
+  </entry>
+</feed>
+""".strip()
+
+
+class Json403ThenRssResponse:
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self.text = RSS_XML
+
+    def raise_for_status(self) -> None:
+        if self._url.endswith(".json"):
+            raise httpx.HTTPStatusError(
+                "forbidden",
+                request=httpx.Request("GET", "https://www.reddit.com"),
+                response=httpx.Response(403),
+            )
+
+    def json(self) -> object:
+        raise AssertionError("json() should not be called")
+
+
+class Json403ThenRssClient:
+    def __init__(self, **_: object) -> None:
+        return None
+
+    async def __aenter__(self) -> "Json403ThenRssClient":
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    async def get(self, url: str, headers: dict[str, str] | None = None) -> Json403ThenRssResponse:
+        if url.endswith(".json"):
+            assert headers is not None
+            assert headers["Accept"] == "application/json"
+        return Json403ThenRssResponse(url)
+
 
 def test_to_reddit_json_url_normalizes_host_and_path() -> None:
     url = "https://old.reddit.com/r/selfhosted/comments/abc123/example/?utm_source=share"
@@ -82,52 +128,10 @@ def test_reddit_loader_prefers_json_endpoint(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_reddit_loader_falls_back_when_json_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    class FakeResponse:
-        def __init__(self, url: str) -> None:
-            self._url = url
-            self.text = """
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <title>Demo Feed</title>
-  <entry>
-    <title>Post title</title>
-    <author><name>alice</name></author>
-    <updated>2026-03-27T06:12:49+00:00</updated>
-    <content type="html">&lt;div&gt;&lt;p&gt;RSS content&lt;/p&gt;&lt;/div&gt;</content>
-  </entry>
-</feed>
-""".strip()
-
-        def raise_for_status(self) -> None:
-            if self._url.endswith(".json"):
-                raise httpx.HTTPStatusError(
-                    "forbidden",
-                    request=httpx.Request("GET", "https://www.reddit.com"),
-                    response=httpx.Response(403),
-                )
-
-        def json(self) -> object:
-            raise AssertionError("json() should not be called")
-
-    class FakeClient:
-        def __init__(self, **_: object) -> None:
-            return None
-
-        async def __aenter__(self) -> "FakeClient":
-            return self
-
-        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-            return None
-
-        async def get(self, url: str, headers: dict[str, str] | None = None) -> FakeResponse:
-            if url.endswith(".json"):
-                assert headers is not None
-                assert headers["Accept"] == "application/json"
-            return FakeResponse(url)
-
     async def fake_fallback(self: RedditLoader, url: str) -> str:
         return f"fallback:{url}"
 
-    monkeypatch.setattr(reddit.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(reddit.httpx, "AsyncClient", Json403ThenRssClient)
     monkeypatch.setattr(RedditLoader, "_load_via_old_reddit", fake_fallback)
 
     result = asyncio.run(RedditLoader().load("https://www.reddit.com/r/python/comments/abc/demo/"))

--- a/tests/loaders/test_reddit.py
+++ b/tests/loaders/test_reddit.py
@@ -1,0 +1,136 @@
+import asyncio
+
+import httpx
+import pytest
+
+from kabigon.loaders import reddit
+from kabigon.loaders.reddit import RedditLoader
+from kabigon.loaders.reddit import to_reddit_json_url
+from kabigon.loaders.reddit import to_reddit_rss_url
+
+
+def test_to_reddit_json_url_normalizes_host_and_path() -> None:
+    url = "https://old.reddit.com/r/selfhosted/comments/abc123/example/?utm_source=share"
+    assert to_reddit_json_url(url) == "https://www.reddit.com/r/selfhosted/comments/abc123/example.json"
+
+
+def test_to_reddit_rss_url_normalizes_host_and_path() -> None:
+    url = "https://old.reddit.com/r/selfhosted/comments/abc123/example/?utm_source=share"
+    assert to_reddit_rss_url(url) == "https://www.reddit.com/r/selfhosted/comments/abc123/example/.rss"
+
+
+def test_reddit_loader_prefers_json_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> object:
+            return [
+                {
+                    "data": {
+                        "children": [
+                            {
+                                "data": {
+                                    "title": "Nomad selfhosted trip planner",
+                                    "author": "alice",
+                                    "subreddit": "selfhosted",
+                                    "score": 123,
+                                    "permalink": "/r/selfhosted/comments/abc123/example/",
+                                    "selftext": "Great project",
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "data": {
+                        "children": [
+                            {"kind": "t1", "data": {"author": "bob", "score": 7, "body": "Looks useful!"}},
+                        ]
+                    }
+                },
+            ]
+
+    class FakeClient:
+        def __init__(self, **_: object) -> None:
+            return None
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def get(self, url: str, headers: dict[str, str]) -> FakeResponse:
+            assert url == "https://www.reddit.com/r/selfhosted/comments/abc123/example.json"
+            assert headers["Accept"] == "application/json"
+            return FakeResponse()
+
+    async def fail_fallback(self: RedditLoader, url: str) -> str:
+        raise AssertionError(f"fallback should not be called: {url}")
+
+    monkeypatch.setattr(reddit.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(RedditLoader, "_load_via_old_reddit", fail_fallback)
+
+    result = asyncio.run(
+        RedditLoader().load("https://www.reddit.com/r/selfhosted/comments/abc123/example/?utm_source=share")
+    )
+    assert "Nomad selfhosted trip planner" in result
+    assert "Great project" in result
+    assert "u/bob" in result
+    assert "Looks useful!" in result
+
+
+def test_reddit_loader_falls_back_when_json_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        def __init__(self, url: str) -> None:
+            self._url = url
+            self.text = """
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Demo Feed</title>
+  <entry>
+    <title>Post title</title>
+    <author><name>alice</name></author>
+    <updated>2026-03-27T06:12:49+00:00</updated>
+    <content type="html">&lt;div&gt;&lt;p&gt;RSS content&lt;/p&gt;&lt;/div&gt;</content>
+  </entry>
+</feed>
+""".strip()
+
+        def raise_for_status(self) -> None:
+            if self._url.endswith(".json"):
+                raise httpx.HTTPStatusError(
+                    "forbidden",
+                    request=httpx.Request("GET", "https://www.reddit.com"),
+                    response=httpx.Response(403),
+                )
+
+        def json(self) -> object:
+            raise AssertionError("json() should not be called")
+
+    class FakeClient:
+        def __init__(self, **_: object) -> None:
+            return None
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def get(self, url: str, headers: dict[str, str] | None = None) -> FakeResponse:
+            if url.endswith(".json"):
+                assert headers is not None
+                assert headers["Accept"] == "application/json"
+            return FakeResponse(url)
+
+    async def fake_fallback(self: RedditLoader, url: str) -> str:
+        return f"fallback:{url}"
+
+    monkeypatch.setattr(reddit.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(RedditLoader, "_load_via_old_reddit", fake_fallback)
+
+    result = asyncio.run(RedditLoader().load("https://www.reddit.com/r/python/comments/abc/demo/"))
+    assert "Demo Feed" in result
+    assert "Post title" in result
+    assert "RSS content" in result

--- a/tests/loaders/test_truthsocial.py
+++ b/tests/loaders/test_truthsocial.py
@@ -71,7 +71,7 @@ class FakePage:
         self.goto_timeout = 0.0
         self.selector_timeout = 0.0
 
-    async def route(self, pattern: str, handler) -> None:  # type: ignore[no-untyped-def]
+    async def route(self, pattern: str, handler) -> None:
         self.route_pattern = pattern
         self.route_handler = handler
 
@@ -127,7 +127,7 @@ class FakePlaywrightContextManager:
     async def __aenter__(self) -> FakePlaywright:
         return self._playwright
 
-    async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
         return False
 
 


### PR DESCRIPTION
## Summary
- rework Reddit loader fallback flow to `JSON -> RSS -> old.reddit` so blocked JSON requests can still return content
- add Reddit-specific parsing for JSON payloads and Atom RSS feed payloads
- add loader tests for JSON URL normalization, RSS URL normalization, JSON success path, and JSON failure fallback path
- remove 2 stale `type: ignore` markers in TruthSocial tests to satisfy `ty-check`
- add a MEMORY GOTCHA entry documenting that RSS can be blocked when browser-like headers are forced

## Why
Reddit now returns `403 Blocked` for some JSON and old-reddit access patterns in this environment. RSS remained reachable in practical testing, so adding RSS as an intermediate fallback restores usable extraction for affected links.

## Impact
- `kabigon --loader reddit <reddit-url>` is more resilient when Reddit blocks JSON.
- Existing fallback to Playwright is kept for cases where both JSON and RSS fail.

## Validation
- `uv run pytest -v -s tests/loaders/test_reddit.py`
- `prek run -a`
- manual run: `uv run kabigon --loader reddit https://www.reddit.com/r/selfhosted/comments/1s4w5wx/nomad_selfhosted_trip_planner_with_realtime/`
