### PR TITLE
refactor: centralize source applicability

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,10 @@ _Avoid_: pipeline, service, resolver
 Fallback behavior inside one Loader Adapter, such as trying multiple source-specific fetch strategies before returning content.
 _Avoid_: pipeline fallback, execution fallback
 
+**Source applicability**:
+The rules that decide whether an input belongs to a source-specific Pipeline before Loaders run.
+_Avoid_: route matcher, loader validation, URL guard
+
 ## Relationships
 
 - A **Pipeline catalog** owns many **Pipelines**
@@ -46,6 +50,7 @@ _Avoid_: pipeline fallback, execution fallback
 - A **Load chain** turns an **Execution plan** into runnable **Loaders**
 - A **Loader** is attempted within an **Execution plan**
 - A **Loader-internal fallback** stays inside one **Loader** implementation
+- **Source applicability** decides whether a **Pipeline** applies before the **Execution plan** is built
 
 ## Architecture Notes
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -7,6 +7,7 @@
 - Keep `openai_web` on `firecrawl` only with `NO_FALLBACK`; do not append default fallback loaders for that route.
 - For local example runs, execute the user's exact command first and only add env overrides (for example `UV_CACHE_DIR`) after reproducing a concrete failure.
 - Reddit RSS fallback can return 403 when using browser-like request headers; fetch RSS with default httpx headers.
+- Treat CLI `--loader` and direct `kabigon.loaders.*` usage as advanced escape hatches; the preferred public interface is automatic Pipeline planning through `kabigon <url>` / `kabigon.load_url(url)`.
 
 ## TASTE
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,11 @@ kabigon https://www.youtube.com/watch?v=dQw4w9WgXcQ
 # List all available loaders
 kabigon --list
 
-# Use a specific loader (or a comma-separated chain)
+# Advanced: bypass automatic planning with a specific loader or loader chain
 kabigon --loader youtube https://www.youtube.com/watch?v=dQw4w9WgXcQ
-kabigon --loader youtube,playwright https://www.youtube.com/watch?v=dQw4w9WgXcQ
 ```
 
-Without `--loader`, kabigon routes the URL to a source-specific pipeline first, then falls back to the remaining default loaders without repeating already-attempted ones.
+By default, kabigon routes the URL to a source-specific pipeline first, then falls back to the remaining default loaders without repeating already-attempted ones. Prefer this automatic path unless you are debugging or intentionally bypassing pipeline planning.
 
 More examples:
 
@@ -115,9 +114,9 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-### Custom Loader Chains
+### Advanced Loader Chains
 
-Use `Compose` to build an explicit loader order that tries loaders in sequence:
+Most callers should use `kabigon.load_url()` or `kabigon.load_url_sync()` so pipeline planning, targeted loaders, and fallback policy stay in one place. For debugging or advanced experiments, use `Compose` to build an explicit loader order that tries loaders in sequence:
 
 ```python
 from kabigon.loaders import Compose, TwitterLoader, YoutubeLoader, PlaywrightLoader
@@ -146,8 +145,8 @@ print(loaders)
 
 ### API Summary
 
-| Style | One-liner | Custom chain |
-|-------|-----------|--------------|
+| Style | Recommended interface | Advanced loader chain |
+|-------|-----------------------|-----------------------|
 | **Sync** | `kabigon.load_url_sync(url)` | `loader.load_sync(url)` |
 | **Async** | `await kabigon.load_url(url)` | `await loader.load(url)` |
 | **Batch** | `await asyncio.gather(*[kabigon.load_url(u) for u in urls])` | `await asyncio.gather(*[loader.load(u) for u in urls])` |

--- a/docs/CLI_DESIGN.md
+++ b/docs/CLI_DESIGN.md
@@ -12,7 +12,7 @@ kabigon https://www.youtube.com/watch?v=dQw4w9WgXcQ
 # List supported loaders
 kabigon --list
 
-# Explicit loader selection
+# Advanced escape hatch: explicit loader selection bypasses automatic pipeline planning
 kabigon --loader playwright https://example.com
 kabigon --loader httpx https://example.com
 kabigon --loader firecrawl https://example.com
@@ -27,6 +27,6 @@ kabigon --loader reel https://www.instagram.com/reel/CuA0XYZ1234/
 kabigon --loader github https://github.com/anthropics/claude-code/blob/main/plugins/ralph-wiggum/README.md
 kabigon --loader pdf https://example.com/document.pdf
 
-# Compose loaders in order
+# Advanced escape hatch: compose loaders in order
 kabigon --loader youtube,playwright https://www.youtube.com/watch?v=dQw4w9WgXcQ
 ```

--- a/src/kabigon/application/pipeline_catalog.py
+++ b/src/kabigon/application/pipeline_catalog.py
@@ -5,6 +5,10 @@ from dataclasses import dataclass
 from enum import StrEnum
 from urllib.parse import urlparse
 
+from .source_applicability import is_github_url
+from .source_applicability import is_pdf_target
+from .source_applicability import is_youtube_video_url
+
 Matcher = Callable[[str], bool]
 
 
@@ -41,14 +45,6 @@ def _host(url: str) -> str:
     return urlparse(url).netloc.lower()
 
 
-def _is_http_url(url: str) -> bool:
-    return url.startswith(("http://", "https://"))
-
-
-def _is_pdf_path(url: str) -> bool:
-    return urlparse(url).path.lower().endswith(".pdf")
-
-
 def _is_ptt_url(url: str) -> bool:
     return _host(url) == "www.ptt.cc"
 
@@ -75,15 +71,7 @@ def _is_reddit_url(url: str) -> bool:
 
 
 def _is_youtube_url(url: str) -> bool:
-    return _host(url) in {
-        "youtu.be",
-        "m.youtube.com",
-        "music.youtube.com",
-        "youtube.com",
-        "www.youtube.com",
-        "www.youtube-nocookie.com",
-        "vid.plus",
-    }
+    return is_youtube_video_url(url)
 
 
 def _is_reel_url(url: str) -> bool:
@@ -91,7 +79,7 @@ def _is_reel_url(url: str) -> bool:
 
 
 def _is_github_url(url: str) -> bool:
-    return _host(url) in {"github.com", "raw.githubusercontent.com"}
+    return is_github_url(url)
 
 
 def _is_bbc_url(url: str) -> bool:
@@ -109,9 +97,7 @@ def _is_openai_web_url(url: str) -> bool:
 
 
 def _is_pdf_url(url: str) -> bool:
-    if not _is_http_url(url):
-        return True
-    return _is_pdf_path(url)
+    return is_pdf_target(url)
 
 
 _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (

--- a/src/kabigon/application/source_applicability.py
+++ b/src/kabigon/application/source_applicability.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+from kabigon.domain.errors import InvalidURLError
+from kabigon.domain.errors import KabigonError
+
+YOUTUBE_ALLOWED_SCHEMES = {
+    "http",
+    "https",
+}
+YOUTUBE_ALLOWED_NETLOCS = {
+    "youtu.be",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtube.com",
+    "www.youtube.com",
+    "www.youtube-nocookie.com",
+    "vid.plus",
+}
+GITHUB_HOST = "github.com"
+RAW_GITHUB_HOST = "raw.githubusercontent.com"
+
+
+class UnsupportedURLSchemeError(KabigonError):
+    def __init__(self, scheme: str) -> None:
+        super().__init__(f"unsupported URL scheme: {scheme}")
+
+
+class UnsupportedURLNetlocError(KabigonError):
+    def __init__(self, netloc: str) -> None:
+        super().__init__(f"unsupported URL netloc: {netloc}")
+
+
+class VideoIDError(KabigonError):
+    def __init__(self, video_id: str) -> None:
+        super().__init__(f"invalid video ID: {video_id}")
+
+
+class NoVideoIDFoundError(KabigonError):
+    def __init__(self, url: str) -> None:
+        super().__init__(f"no video found in URL: {url}")
+
+
+@dataclass(frozen=True)
+class YouTubeVideoTarget:
+    url: str
+    video_id: str
+
+
+@dataclass(frozen=True)
+class GitHubTarget:
+    url: str
+    raw_url: str | None = None
+
+    @property
+    def is_raw_content(self) -> bool:
+        return self.raw_url is not None
+
+
+@dataclass(frozen=True)
+class PDFTarget:
+    target: str
+
+
+def parse_youtube_video_target(url: str) -> YouTubeVideoTarget:
+    parsed_url = urlparse(url)
+
+    if parsed_url.scheme not in YOUTUBE_ALLOWED_SCHEMES:
+        raise UnsupportedURLSchemeError(parsed_url.scheme)
+
+    if parsed_url.netloc not in YOUTUBE_ALLOWED_NETLOCS:
+        raise UnsupportedURLNetlocError(parsed_url.netloc)
+
+    path = parsed_url.path
+    if path.endswith("/watch"):
+        parsed_query = parse_qs(parsed_url.query)
+        if "v" not in parsed_query:
+            raise NoVideoIDFoundError(url)
+        video_id = parsed_query["v"][0]
+    else:
+        stripped_path = path.lstrip("/")
+        if not stripped_path:
+            raise NoVideoIDFoundError(url)
+        video_id = stripped_path.split("/")[-1]
+
+    if len(video_id) != 11:
+        raise VideoIDError(video_id)
+
+    return YouTubeVideoTarget(url=url, video_id=video_id)
+
+
+def is_youtube_video_url(url: str) -> bool:
+    try:
+        parse_youtube_video_target(url)
+    except (UnsupportedURLSchemeError, UnsupportedURLNetlocError, NoVideoIDFoundError, VideoIDError):
+        return False
+    return True
+
+
+def parse_github_target(url: str) -> GitHubTarget:
+    parsed = urlparse(url)
+    if parsed.netloc == RAW_GITHUB_HOST:
+        return GitHubTarget(url=url, raw_url=url)
+
+    if parsed.netloc != GITHUB_HOST:
+        raise InvalidURLError(url, "GitHub")
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) >= 5 and parts[2] == "blob":
+        owner, repo, _, ref = parts[:4]
+        path = "/".join(parts[4:])
+        if not path:
+            raise InvalidURLError(url, "GitHub blob file")
+        return GitHubTarget(url=url, raw_url=f"https://{RAW_GITHUB_HOST}/{owner}/{repo}/{ref}/{path}")
+
+    return GitHubTarget(url=url)
+
+
+def parse_github_raw_content_target(url: str) -> GitHubTarget:
+    target = parse_github_target(url)
+    if target.raw_url is None:
+        raise InvalidURLError(url, "GitHub blob")
+    return target
+
+
+def is_github_url(url: str) -> bool:
+    try:
+        parse_github_target(url)
+    except InvalidURLError:
+        return False
+    return True
+
+
+def parse_pdf_target(target: str) -> PDFTarget:
+    parsed = urlparse(target)
+    if parsed.scheme in {"http", "https"}:
+        if not parsed.path.lower().endswith(".pdf"):
+            raise InvalidURLError(target, "PDF")
+        return PDFTarget(target=target)
+
+    if Path(target).suffix.lower() != ".pdf":
+        raise InvalidURLError(target, "PDF")
+    return PDFTarget(target=target)
+
+
+def is_pdf_target(target: str) -> bool:
+    try:
+        parse_pdf_target(target)
+    except InvalidURLError:
+        return False
+    return True
+
+
+__all__ = [
+    "GitHubTarget",
+    "NoVideoIDFoundError",
+    "PDFTarget",
+    "UnsupportedURLNetlocError",
+    "UnsupportedURLSchemeError",
+    "VideoIDError",
+    "YouTubeVideoTarget",
+    "is_github_url",
+    "is_pdf_target",
+    "is_youtube_video_url",
+    "parse_github_raw_content_target",
+    "parse_github_target",
+    "parse_pdf_target",
+    "parse_youtube_video_target",
+]

--- a/src/kabigon/loaders/github.py
+++ b/src/kabigon/loaders/github.py
@@ -4,14 +4,14 @@ from urllib.parse import urlparse
 
 import httpx
 
+from kabigon.application.source_applicability import RAW_GITHUB_HOST
+from kabigon.application.source_applicability import parse_github_raw_content_target
+from kabigon.application.source_applicability import parse_github_target
 from kabigon.domain.errors import InvalidURLError
 from kabigon.domain.loader import Loader
 
 from .html_extractors import extract_first_tag_subtree
 from .utils import html_to_markdown
-
-GITHUB_HOST = "github.com"
-RAW_GITHUB_HOST = "raw.githubusercontent.com"
 
 _IGNORED_TAGS = {
     "script",
@@ -25,9 +25,7 @@ _IGNORED_TAGS = {
 
 
 def check_github_url(url: str) -> None:
-    host = urlparse(url).netloc
-    if host not in {GITHUB_HOST, RAW_GITHUB_HOST}:
-        raise InvalidURLError(url, "GitHub")
+    parse_github_target(url)
 
 
 def to_raw_github_url(url: str) -> str:
@@ -37,23 +35,7 @@ def to_raw_github_url(url: str) -> str:
       - https://github.com/<owner>/<repo>/blob/<ref>/<path>
       - https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>
     """
-    parsed = urlparse(url)
-    if parsed.netloc == RAW_GITHUB_HOST:
-        return url
-
-    if parsed.netloc != GITHUB_HOST:
-        raise InvalidURLError(url, "GitHub")
-
-    parts = [p for p in parsed.path.split("/") if p]
-    if len(parts) < 5 or parts[2] != "blob":
-        raise InvalidURLError(url, "GitHub blob")
-
-    owner, repo, _, ref = parts[:4]
-    path = "/".join(parts[4:])
-    if not path:
-        raise InvalidURLError(url, "GitHub blob file")
-
-    return f"https://{RAW_GITHUB_HOST}/{owner}/{repo}/{ref}/{path}"
+    return parse_github_raw_content_target(url).raw_url or url
 
 
 def extract_main_html(html: str) -> str:

--- a/src/kabigon/loaders/pdf.py
+++ b/src/kabigon/loaders/pdf.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 from pypdf import PdfReader
 
+from kabigon.application.source_applicability import parse_pdf_target
 from kabigon.domain.errors import LoaderContentError
 from kabigon.domain.errors import LoaderNotApplicableError
 from kabigon.domain.loader import Loader
@@ -22,6 +23,7 @@ DEFAULT_HEADERS = {
 class PDFLoader(Loader):
     async def load(self, url_or_file: str) -> str:  # ty:ignore[invalid-method-override]
         logger.debug("[PDFLoader] Processing: %s", url_or_file)
+        parse_pdf_target(url_or_file)
 
         if not url_or_file.startswith("http"):
             # Local file

--- a/src/kabigon/loaders/youtube.py
+++ b/src/kabigon/loaders/youtube.py
@@ -1,11 +1,13 @@
 import asyncio
 import logging
-from urllib.parse import parse_qs
-from urllib.parse import urlparse
 
 from youtube_transcript_api import YouTubeTranscriptApi
 
-from kabigon.domain.errors import KabigonError
+from kabigon.application.source_applicability import NoVideoIDFoundError
+from kabigon.application.source_applicability import UnsupportedURLNetlocError
+from kabigon.application.source_applicability import UnsupportedURLSchemeError
+from kabigon.application.source_applicability import VideoIDError
+from kabigon.application.source_applicability import parse_youtube_video_target
 from kabigon.domain.errors import LoaderContentError
 from kabigon.domain.errors import LoaderNotApplicableError
 from kabigon.domain.loader import Loader
@@ -43,39 +45,6 @@ DEFAULT_LANGUAGES = [
     "ar",  # Arabic
     "hi",  # Hindi
 ]
-ALLOWED_SCHEMES = {
-    "http",
-    "https",
-}
-ALLOWED_NETLOCS = {
-    "youtu.be",
-    "m.youtube.com",
-    "music.youtube.com",
-    "youtube.com",
-    "www.youtube.com",
-    "www.youtube-nocookie.com",
-    "vid.plus",
-}
-
-
-class UnsupportedURLSchemeError(KabigonError):
-    def __init__(self, scheme: str) -> None:
-        super().__init__(f"unsupported URL scheme: {scheme}")
-
-
-class UnsupportedURLNetlocError(KabigonError):
-    def __init__(self, netloc: str) -> None:
-        super().__init__(f"unsupported URL netloc: {netloc}")
-
-
-class VideoIDError(KabigonError):
-    def __init__(self, video_id: str) -> None:
-        super().__init__(f"invalid video ID: {video_id}")
-
-
-class NoVideoIDFoundError(KabigonError):
-    def __init__(self, url: str) -> None:
-        super().__init__(f"no video found in URL: {url}")
 
 
 def parse_video_id(url: str) -> str:
@@ -107,32 +76,7 @@ def parse_video_id(url: str) -> str:
         >>> parse_video_id("https://youtu.be/dQw4w9WgXcQ")
         'dQw4w9WgXcQ'
     """
-    parsed_url = urlparse(url)
-
-    if parsed_url.scheme not in ALLOWED_SCHEMES:
-        raise UnsupportedURLSchemeError(parsed_url.scheme)
-
-    if parsed_url.netloc not in ALLOWED_NETLOCS:
-        raise UnsupportedURLNetlocError(parsed_url.netloc)
-
-    path = parsed_url.path
-
-    if path.endswith("/watch"):
-        query = parsed_url.query
-        parsed_query = parse_qs(query)
-        if "v" in parsed_query:
-            ids = parsed_query["v"]
-            video_id = ids[0]
-        else:
-            raise NoVideoIDFoundError(url)
-    else:
-        stripped_path = parsed_url.path.lstrip("/")
-        video_id = stripped_path.split("/")[-1]
-
-    if len(video_id) != 11:  # Video IDs are 11 characters long
-        raise VideoIDError(video_id)
-
-    return video_id
+    return parse_youtube_video_target(url).video_id
 
 
 def check_youtube_url(url: str) -> None:

--- a/tests/loaders/test_github.py
+++ b/tests/loaders/test_github.py
@@ -95,6 +95,7 @@ def test_to_raw_github_url_error(url: str) -> None:
 @pytest.mark.parametrize(
     "url",
     [
+        "https://github.com/anthropics/claude-code",
         "https://github.com/anthropics/claude-code/blob/main/plugins/ralph-wiggum/README.md",
         "https://raw.githubusercontent.com/anthropics/claude-code/main/plugins/ralph-wiggum/README.md",
     ],

--- a/tests/test_load_url.py
+++ b/tests/test_load_url.py
@@ -31,8 +31,19 @@ def test_build_execution_plan_for_url_youtube_is_targeted_then_fallback() -> Non
     assert len(execution_plan) == len(set(execution_plan))
 
 
+def test_build_execution_plan_for_youtube_playlist_uses_default_order() -> None:
+    execution_plan = explain_load_chain("https://www.youtube.com/playlist?list=PL123").execution_plan
+
+    assert execution_plan == DEFAULT_FALLBACK_LOADERS
+
+
 def test_build_execution_plan_for_url_unknown_uses_default_order() -> None:
     execution_plan = explain_load_chain("https://example.com/hello").execution_plan
+    assert execution_plan == DEFAULT_FALLBACK_LOADERS
+
+
+def test_build_execution_plan_for_non_pdf_file_uses_default_order() -> None:
+    execution_plan = explain_load_chain("not-a-valid-url").execution_plan
     assert execution_plan == DEFAULT_FALLBACK_LOADERS
 
 

--- a/tests/test_pipeline_catalog.py
+++ b/tests/test_pipeline_catalog.py
@@ -14,6 +14,10 @@ def test_match_pipeline_youtube() -> None:
     assert pipeline.targeted_loaders == ("youtube", "youtube-ytdlp")
 
 
+def test_match_pipeline_youtube_playlist_is_not_video_pipeline() -> None:
+    assert match_pipeline("https://www.youtube.com/playlist?list=PL123") is None
+
+
 def test_match_pipeline_reddit() -> None:
     pipeline = match_pipeline("https://www.reddit.com/r/python/comments/abc/example/")
 
@@ -36,8 +40,19 @@ def test_match_pipeline_non_http_pdf_path() -> None:
     assert pipeline.targeted_loaders == ("pdf",)
 
 
+def test_match_pipeline_non_http_non_pdf_path_returns_none() -> None:
+    assert match_pipeline("not-a-valid-url") is None
+
+
 def test_match_pipeline_github_pdf_prefers_github() -> None:
     pipeline = match_pipeline("https://github.com/a/b/blob/main/demo.pdf")
+
+    assert pipeline is not None
+    assert pipeline.name == "github"
+
+
+def test_match_pipeline_raw_github() -> None:
+    pipeline = match_pipeline("https://raw.githubusercontent.com/a/b/main/README.md")
 
     assert pipeline is not None
     assert pipeline.name == "github"


### PR DESCRIPTION
## Summary
- Add a Source applicability module for YouTube, GitHub, and PDF target decisions.
- Reuse shared target parsing from the Pipeline catalog and defensive Loader paths.
- Mark explicit loader selection and direct loader chains as advanced escape hatches in docs.

## Verification
- uv run ruff check .
- uv run ty check .
- uv run pytest -v -s --cov=src tests