### PR TITLE
refactor: centralize twitter applicability

### DIFF
--- a/src/kabigon/application/pipeline_catalog.py
+++ b/src/kabigon/application/pipeline_catalog.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 from .source_applicability import is_github_url
 from .source_applicability import is_pdf_target
+from .source_applicability import is_twitter_url
 from .source_applicability import is_youtube_video_url
 
 Matcher = Callable[[str], bool]
@@ -50,16 +51,7 @@ def _is_ptt_url(url: str) -> bool:
 
 
 def _is_twitter_url(url: str) -> bool:
-    return _host(url) in {
-        "twitter.com",
-        "x.com",
-        "fxtwitter.com",
-        "vxtwitter.com",
-        "fixvx.com",
-        "twittpr.com",
-        "api.fxtwitter.com",
-        "fixupx.com",
-    }
+    return is_twitter_url(url)
 
 
 def _is_truthsocial_url(url: str) -> bool:

--- a/src/kabigon/application/source_applicability.py
+++ b/src/kabigon/application/source_applicability.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
+from urllib.parse import urlunparse
 
 from kabigon.domain.errors import InvalidURLError
 from kabigon.domain.errors import KabigonError
+from kabigon.domain.errors import LoaderNotApplicableError
 
 YOUTUBE_ALLOWED_SCHEMES = {
     "http",
@@ -23,6 +25,16 @@ YOUTUBE_ALLOWED_NETLOCS = {
 }
 GITHUB_HOST = "github.com"
 RAW_GITHUB_HOST = "raw.githubusercontent.com"
+TWITTER_DOMAINS = (
+    "twitter.com",
+    "x.com",
+    "fxtwitter.com",
+    "vxtwitter.com",
+    "fixvx.com",
+    "twittpr.com",
+    "api.fxtwitter.com",
+    "fixupx.com",
+)
 
 
 class UnsupportedURLSchemeError(KabigonError):
@@ -64,6 +76,12 @@ class GitHubTarget:
 @dataclass(frozen=True)
 class PDFTarget:
     target: str
+
+
+@dataclass(frozen=True)
+class TwitterTarget:
+    url: str
+    normalized_url: str
 
 
 def parse_youtube_video_target(url: str) -> YouTubeVideoTarget:
@@ -155,19 +173,38 @@ def is_pdf_target(target: str) -> bool:
     return True
 
 
+def parse_twitter_target(url: str) -> TwitterTarget:
+    parsed = urlparse(url)
+    if parsed.netloc.lower() not in TWITTER_DOMAINS:
+        raise LoaderNotApplicableError("TwitterLoader", url, "URL is not a Twitter/X URL")
+    return TwitterTarget(url=url, normalized_url=str(urlunparse(parsed._replace(netloc="x.com"))))
+
+
+def is_twitter_url(url: str) -> bool:
+    try:
+        parse_twitter_target(url)
+    except LoaderNotApplicableError:
+        return False
+    return True
+
+
 __all__ = [
+    "TWITTER_DOMAINS",
     "GitHubTarget",
     "NoVideoIDFoundError",
     "PDFTarget",
+    "TwitterTarget",
     "UnsupportedURLNetlocError",
     "UnsupportedURLSchemeError",
     "VideoIDError",
     "YouTubeVideoTarget",
     "is_github_url",
     "is_pdf_target",
+    "is_twitter_url",
     "is_youtube_video_url",
     "parse_github_raw_content_target",
     "parse_github_target",
     "parse_pdf_target",
+    "parse_twitter_target",
     "parse_youtube_video_target",
 ]

--- a/src/kabigon/loaders/twitter.py
+++ b/src/kabigon/loaders/twitter.py
@@ -1,8 +1,6 @@
 import asyncio
 import contextlib
 import logging
-from urllib.parse import urlparse
-from urllib.parse import urlunparse
 
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import Page
@@ -11,24 +9,13 @@ from playwright.async_api import Route
 from playwright.async_api import TimeoutError
 from playwright.async_api import async_playwright
 
+from kabigon.application.source_applicability import parse_twitter_target
 from kabigon.domain.errors import LoaderTimeoutError
 from kabigon.domain.loader import Loader
 
-from .url_match import ensure_host_in
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
-TWITTER_DOMAINS = [
-    "twitter.com",
-    "x.com",
-    "fxtwitter.com",
-    "vxtwitter.com",
-    "fixvx.com",
-    "twittpr.com",
-    "api.fxtwitter.com",
-    "fixupx.com",
-]
-
 USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 )
@@ -41,11 +28,14 @@ TWEET_READY_SELECTORS = [
 
 
 def replace_domain(url: str, new_domain: str = "x.com") -> str:
-    return str(urlunparse(urlparse(url)._replace(netloc=new_domain)))
+    target = parse_twitter_target(url)
+    if new_domain == "x.com":
+        return target.normalized_url
+    return target.normalized_url.replace("//x.com", f"//{new_domain}", 1)
 
 
 def check_x_url(url: str) -> None:
-    ensure_host_in(url, TWITTER_DOMAINS, loader_name="TwitterLoader", source_name="Twitter/X")
+    parse_twitter_target(url)
 
 
 class TwitterLoader(Loader):

--- a/tests/loaders/test_twitter.py
+++ b/tests/loaders/test_twitter.py
@@ -1,0 +1,35 @@
+import pytest
+
+from kabigon.domain.errors import LoaderNotApplicableError
+from kabigon.loaders.twitter import check_x_url
+from kabigon.loaders.twitter import replace_domain
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://twitter.com/user/status/1",
+        "https://x.com/user/status/1",
+        "https://fxtwitter.com/user/status/1",
+        "https://vxtwitter.com/user/status/1",
+        "https://fixvx.com/user/status/1",
+        "https://twittpr.com/user/status/1",
+        "https://api.fxtwitter.com/user/status/1",
+        "https://fixupx.com/user/status/1",
+    ],
+)
+def test_check_x_url_accepts_supported_hosts(url: str) -> None:
+    check_x_url(url)
+
+
+def test_check_x_url_rejects_unknown_host() -> None:
+    with pytest.raises(LoaderNotApplicableError):
+        check_x_url("https://example.com/user/status/1")
+
+
+def test_replace_domain_normalizes_to_x() -> None:
+    assert replace_domain("https://fxtwitter.com/user/status/1") == "https://x.com/user/status/1"
+
+
+def test_replace_domain_accepts_custom_domain() -> None:
+    assert replace_domain("https://x.com/user/status/1", "twitter.com") == "https://twitter.com/user/status/1"

--- a/tests/test_pipeline_catalog.py
+++ b/tests/test_pipeline_catalog.py
@@ -27,6 +27,20 @@ def test_match_pipeline_reddit() -> None:
     assert pipeline.targeted_loaders == ("reddit",)
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://x.com/user/status/1",
+        "https://fixupx.com/user/status/1",
+    ],
+)
+def test_match_pipeline_twitter_hosts(url: str) -> None:
+    pipeline = match_pipeline(url)
+
+    assert pipeline is not None
+    assert pipeline.name == "twitter"
+
+
 def test_match_pipeline_unknown_returns_none() -> None:
     assert match_pipeline("https://example.com/path") is None
 


### PR DESCRIPTION
## Summary
- Move Twitter/X host applicability and URL normalization into the shared Source applicability module.
- Reuse the shared Twitter target parsing from both the Pipeline catalog and TwitterLoader.
- Add regression tests for supported Twitter/X hosts and domain normalization.

## Verification
- uv run ruff check .
- uv run ty check .
- uv run pytest -v -s --cov=src tests