### PR TITLE
refactor: centralize truthsocial applicability

### DIFF
--- a/src/kabigon/application/pipeline_catalog.py
+++ b/src/kabigon/application/pipeline_catalog.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 from .source_applicability import is_github_url
 from .source_applicability import is_pdf_target
+from .source_applicability import is_truthsocial_url
 from .source_applicability import is_youtube_video_url
 
 Matcher = Callable[[str], bool]
@@ -63,7 +64,7 @@ def _is_twitter_url(url: str) -> bool:
 
 
 def _is_truthsocial_url(url: str) -> bool:
-    return _host(url) in {"truthsocial.com", "www.truthsocial.com"}
+    return is_truthsocial_url(url)
 
 
 def _is_reddit_url(url: str) -> bool:

--- a/src/kabigon/application/source_applicability.py
+++ b/src/kabigon/application/source_applicability.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 from kabigon.domain.errors import InvalidURLError
 from kabigon.domain.errors import KabigonError
+from kabigon.domain.errors import LoaderNotApplicableError
 
 YOUTUBE_ALLOWED_SCHEMES = {
     "http",
@@ -23,6 +24,10 @@ YOUTUBE_ALLOWED_NETLOCS = {
 }
 GITHUB_HOST = "github.com"
 RAW_GITHUB_HOST = "raw.githubusercontent.com"
+TRUTHSOCIAL_DOMAINS = (
+    "truthsocial.com",
+    "www.truthsocial.com",
+)
 
 
 class UnsupportedURLSchemeError(KabigonError):
@@ -64,6 +69,11 @@ class GitHubTarget:
 @dataclass(frozen=True)
 class PDFTarget:
     target: str
+
+
+@dataclass(frozen=True)
+class TruthSocialTarget:
+    url: str
 
 
 def parse_youtube_video_target(url: str) -> YouTubeVideoTarget:
@@ -155,19 +165,38 @@ def is_pdf_target(target: str) -> bool:
     return True
 
 
+def parse_truthsocial_target(url: str) -> TruthSocialTarget:
+    parsed = urlparse(url)
+    if parsed.netloc.lower() not in TRUTHSOCIAL_DOMAINS:
+        raise LoaderNotApplicableError("TruthSocialLoader", url, "Not a Truth Social URL")
+    return TruthSocialTarget(url=url)
+
+
+def is_truthsocial_url(url: str) -> bool:
+    try:
+        parse_truthsocial_target(url)
+    except LoaderNotApplicableError:
+        return False
+    return True
+
+
 __all__ = [
+    "TRUTHSOCIAL_DOMAINS",
     "GitHubTarget",
     "NoVideoIDFoundError",
     "PDFTarget",
+    "TruthSocialTarget",
     "UnsupportedURLNetlocError",
     "UnsupportedURLSchemeError",
     "VideoIDError",
     "YouTubeVideoTarget",
     "is_github_url",
     "is_pdf_target",
+    "is_truthsocial_url",
     "is_youtube_video_url",
     "parse_github_raw_content_target",
     "parse_github_target",
     "parse_pdf_target",
+    "parse_truthsocial_target",
     "parse_youtube_video_target",
 ]

--- a/src/kabigon/loaders/truthsocial.py
+++ b/src/kabigon/loaders/truthsocial.py
@@ -7,18 +7,13 @@ from playwright.async_api import Route
 from playwright.async_api import TimeoutError
 from playwright.async_api import async_playwright
 
+from kabigon.application.source_applicability import parse_truthsocial_target
 from kabigon.domain.errors import LoaderTimeoutError
 from kabigon.domain.loader import Loader
 
-from .url_match import ensure_host_in
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
-
-TRUTHSOCIAL_DOMAINS = [
-    "truthsocial.com",
-    "www.truthsocial.com",
-]
 
 USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
@@ -34,7 +29,7 @@ def check_truthsocial_url(url: str) -> None:
     Raises:
         LoaderNotApplicableError: If URL is not from Truth Social
     """
-    ensure_host_in(url, TRUTHSOCIAL_DOMAINS, loader_name="TruthSocialLoader", source_name="Truth Social")
+    parse_truthsocial_target(url)
 
 
 class TruthSocialLoader(Loader):

--- a/tests/test_pipeline_catalog.py
+++ b/tests/test_pipeline_catalog.py
@@ -27,6 +27,20 @@ def test_match_pipeline_reddit() -> None:
     assert pipeline.targeted_loaders == ("reddit",)
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://truthsocial.com/@realDonaldTrump/posts/123456",
+        "https://www.truthsocial.com/@user/posts/789",
+    ],
+)
+def test_match_pipeline_truthsocial_hosts(url: str) -> None:
+    pipeline = match_pipeline(url)
+
+    assert pipeline is not None
+    assert pipeline.name == "truthsocial"
+
+
 def test_match_pipeline_unknown_returns_none() -> None:
     assert match_pipeline("https://example.com/path") is None
 


### PR DESCRIPTION
## Summary
- Move Truth Social host applicability into the shared Source applicability module.
- Reuse shared Truth Social target parsing from both the Pipeline catalog and TruthSocialLoader.
- Add Pipeline catalog regression coverage for supported Truth Social hosts.

## Verification
- uv run ruff check .
- uv run ty check .
- uv run pytest -v -s --cov=src tests