### PR TITLE
refactor: centralize remaining applicability

### DIFF
--- a/src/kabigon/application/pipeline_catalog.py
+++ b/src/kabigon/application/pipeline_catalog.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from urllib.parse import urlparse
 
+from .source_applicability import is_bbc_url
+from .source_applicability import is_cnn_url
 from .source_applicability import is_github_url
+from .source_applicability import is_openai_web_url
 from .source_applicability import is_pdf_target
+from .source_applicability import is_ptt_url
+from .source_applicability import is_reddit_url
+from .source_applicability import is_reel_url
 from .source_applicability import is_truthsocial_url
 from .source_applicability import is_twitter_url
 from .source_applicability import is_youtube_video_url
@@ -43,12 +48,8 @@ class _PipelineEntry:
     matches: Matcher
 
 
-def _host(url: str) -> str:
-    return urlparse(url).netloc.lower()
-
-
 def _is_ptt_url(url: str) -> bool:
-    return _host(url) == "www.ptt.cc"
+    return is_ptt_url(url)
 
 
 def _is_twitter_url(url: str) -> bool:
@@ -60,7 +61,7 @@ def _is_truthsocial_url(url: str) -> bool:
 
 
 def _is_reddit_url(url: str) -> bool:
-    return _host(url) in {"reddit.com", "www.reddit.com", "old.reddit.com"}
+    return is_reddit_url(url)
 
 
 def _is_youtube_url(url: str) -> bool:
@@ -68,7 +69,7 @@ def _is_youtube_url(url: str) -> bool:
 
 
 def _is_reel_url(url: str) -> bool:
-    return url.startswith("https://www.instagram.com/reel")
+    return is_reel_url(url)
 
 
 def _is_github_url(url: str) -> bool:
@@ -76,17 +77,15 @@ def _is_github_url(url: str) -> bool:
 
 
 def _is_bbc_url(url: str) -> bool:
-    host = _host(url)
-    return host == "bbc.com" or host.endswith(".bbc.com")
+    return is_bbc_url(url)
 
 
 def _is_cnn_url(url: str) -> bool:
-    host = _host(url)
-    return host == "cnn.com" or host.endswith(".cnn.com")
+    return is_cnn_url(url)
 
 
 def _is_openai_web_url(url: str) -> bool:
-    return _host(url) in {"openai.com", "www.openai.com", "help.openai.com", "platform.openai.com"}
+    return is_openai_web_url(url)
 
 
 def _is_pdf_url(url: str) -> bool:

--- a/src/kabigon/application/source_applicability.py
+++ b/src/kabigon/application/source_applicability.py
@@ -10,6 +10,8 @@ from kabigon.domain.errors import InvalidURLError
 from kabigon.domain.errors import KabigonError
 from kabigon.domain.errors import LoaderNotApplicableError
 
+BBC_DOMAIN_SUFFIX = "bbc.com"
+CNN_DOMAIN_SUFFIX = "cnn.com"
 YOUTUBE_ALLOWED_SCHEMES = {
     "http",
     "https",
@@ -24,7 +26,20 @@ YOUTUBE_ALLOWED_NETLOCS = {
     "vid.plus",
 }
 GITHUB_HOST = "github.com"
+OPENAI_WEB_HOSTS = (
+    "openai.com",
+    "www.openai.com",
+    "help.openai.com",
+    "platform.openai.com",
+)
+PTT_HOSTS = ("www.ptt.cc",)
 RAW_GITHUB_HOST = "raw.githubusercontent.com"
+REDDIT_DOMAINS = (
+    "reddit.com",
+    "www.reddit.com",
+    "old.reddit.com",
+)
+REEL_PREFIX = "https://www.instagram.com/reel"
 TRUTHSOCIAL_DOMAINS = (
     "truthsocial.com",
     "www.truthsocial.com",
@@ -80,6 +95,31 @@ class GitHubTarget:
 @dataclass(frozen=True)
 class PDFTarget:
     target: str
+
+
+@dataclass(frozen=True)
+class BBCTarget:
+    url: str
+
+
+@dataclass(frozen=True)
+class CNNTarget:
+    url: str
+
+
+@dataclass(frozen=True)
+class PttTarget:
+    url: str
+
+
+@dataclass(frozen=True)
+class RedditTarget:
+    url: str
+
+
+@dataclass(frozen=True)
+class ReelTarget:
+    url: str
 
 
 @dataclass(frozen=True)
@@ -182,6 +222,104 @@ def is_pdf_target(target: str) -> bool:
     return True
 
 
+def _host(url: str) -> str:
+    return urlparse(url).netloc.lower()
+
+
+def _host_in(url: str, hosts: tuple[str, ...]) -> bool:
+    return _host(url) in {host.lower() for host in hosts}
+
+
+def _host_matches_domain_suffix(url: str, domain_suffix: str) -> bool:
+    host = _host(url)
+    normalized_suffix = domain_suffix.lower().lstrip(".")
+    return host == normalized_suffix or host.endswith(f".{normalized_suffix}")
+
+
+def parse_bbc_target(url: str) -> BBCTarget:
+    if not _host_matches_domain_suffix(url, BBC_DOMAIN_SUFFIX):
+        raise LoaderNotApplicableError(
+            "BBCLoader",
+            url,
+            f"Not a BBC URL. Expected domain ending with {BBC_DOMAIN_SUFFIX}",
+        )
+    return BBCTarget(url=url)
+
+
+def is_bbc_url(url: str) -> bool:
+    try:
+        parse_bbc_target(url)
+    except LoaderNotApplicableError:
+        return False
+    return True
+
+
+def parse_cnn_target(url: str) -> CNNTarget:
+    if not _host_matches_domain_suffix(url, CNN_DOMAIN_SUFFIX):
+        raise LoaderNotApplicableError(
+            "CNNLoader",
+            url,
+            f"Not a CNN URL. Expected domain ending with {CNN_DOMAIN_SUFFIX}",
+        )
+    return CNNTarget(url=url)
+
+
+def is_cnn_url(url: str) -> bool:
+    try:
+        parse_cnn_target(url)
+    except LoaderNotApplicableError:
+        return False
+    return True
+
+
+def is_openai_web_url(url: str) -> bool:
+    return _host_in(url, OPENAI_WEB_HOSTS)
+
+
+def parse_ptt_target(url: str) -> PttTarget:
+    if not _host_in(url, PTT_HOSTS):
+        expected = ", ".join(PTT_HOSTS)
+        raise LoaderNotApplicableError("PttLoader", url, f"Not a PTT URL. Expected domains: {expected}")
+    return PttTarget(url=url)
+
+
+def is_ptt_url(url: str) -> bool:
+    try:
+        parse_ptt_target(url)
+    except LoaderNotApplicableError:
+        return False
+    return True
+
+
+def parse_reddit_target(url: str) -> RedditTarget:
+    if not _host_in(url, REDDIT_DOMAINS):
+        expected = ", ".join(REDDIT_DOMAINS)
+        raise LoaderNotApplicableError("RedditLoader", url, f"Not a Reddit URL. Expected domains: {expected}")
+    return RedditTarget(url=url)
+
+
+def is_reddit_url(url: str) -> bool:
+    try:
+        parse_reddit_target(url)
+    except LoaderNotApplicableError:
+        return False
+    return True
+
+
+def parse_reel_target(url: str) -> ReelTarget:
+    if not url.startswith(REEL_PREFIX):
+        raise LoaderNotApplicableError("ReelLoader", url, "Not an Instagram Reel URL")
+    return ReelTarget(url=url)
+
+
+def is_reel_url(url: str) -> bool:
+    try:
+        parse_reel_target(url)
+    except LoaderNotApplicableError:
+        return False
+    return True
+
+
 def parse_truthsocial_target(url: str) -> TruthSocialTarget:
     parsed = urlparse(url)
     if parsed.netloc.lower() not in TRUTHSOCIAL_DOMAINS:
@@ -213,25 +351,47 @@ def is_twitter_url(url: str) -> bool:
 
 
 __all__ = [
+    "BBC_DOMAIN_SUFFIX",
+    "CNN_DOMAIN_SUFFIX",
+    "OPENAI_WEB_HOSTS",
+    "PTT_HOSTS",
+    "REDDIT_DOMAINS",
+    "REEL_PREFIX",
     "TRUTHSOCIAL_DOMAINS",
     "TWITTER_DOMAINS",
+    "BBCTarget",
+    "CNNTarget",
     "GitHubTarget",
     "NoVideoIDFoundError",
     "PDFTarget",
+    "PttTarget",
+    "RedditTarget",
+    "ReelTarget",
     "TruthSocialTarget",
     "TwitterTarget",
     "UnsupportedURLNetlocError",
     "UnsupportedURLSchemeError",
     "VideoIDError",
     "YouTubeVideoTarget",
+    "is_bbc_url",
+    "is_cnn_url",
     "is_github_url",
+    "is_openai_web_url",
     "is_pdf_target",
+    "is_ptt_url",
+    "is_reddit_url",
+    "is_reel_url",
     "is_truthsocial_url",
     "is_twitter_url",
     "is_youtube_video_url",
+    "parse_bbc_target",
+    "parse_cnn_target",
     "parse_github_raw_content_target",
     "parse_github_target",
     "parse_pdf_target",
+    "parse_ptt_target",
+    "parse_reddit_target",
+    "parse_reel_target",
     "parse_truthsocial_target",
     "parse_twitter_target",
     "parse_youtube_video_target",

--- a/src/kabigon/loaders/bbc.py
+++ b/src/kabigon/loaders/bbc.py
@@ -4,17 +4,15 @@ import logging
 
 import httpx
 
+from kabigon.application.source_applicability import parse_bbc_target
 from kabigon.domain.errors import LoaderContentError
 from kabigon.domain.loader import Loader
 
 from .html_extractors import extract_article_body_from_json_ld
 from .html_extractors import extract_first_tag_subtree
-from .url_match import ensure_domain_suffix
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
-
-BBC_DOMAIN_SUFFIX = "bbc.com"
 
 _IGNORED_TAGS = {
     "script",
@@ -25,7 +23,7 @@ _IGNORED_TAGS = {
 
 
 def check_bbc_url(url: str) -> None:
-    ensure_domain_suffix(url, BBC_DOMAIN_SUFFIX, loader_name="BBCLoader", source_name="BBC")
+    parse_bbc_target(url)
 
 
 def extract_bbc_main_html(html: str) -> str:

--- a/src/kabigon/loaders/cnn.py
+++ b/src/kabigon/loaders/cnn.py
@@ -4,17 +4,15 @@ import logging
 
 import httpx
 
+from kabigon.application.source_applicability import parse_cnn_target
 from kabigon.domain.errors import LoaderContentError
 from kabigon.domain.loader import Loader
 
 from .html_extractors import extract_article_body_from_json_ld
 from .html_extractors import extract_first_tag_subtree
-from .url_match import ensure_domain_suffix
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
-
-CNN_DOMAIN_SUFFIX = "cnn.com"
 
 _IGNORED_TAGS = {
     "script",
@@ -25,7 +23,7 @@ _IGNORED_TAGS = {
 
 
 def check_cnn_url(url: str) -> None:
-    ensure_domain_suffix(url, CNN_DOMAIN_SUFFIX, loader_name="CNNLoader", source_name="CNN")
+    parse_cnn_target(url)
 
 
 def extract_cnn_main_html(html: str) -> str:

--- a/src/kabigon/loaders/ptt.py
+++ b/src/kabigon/loaders/ptt.py
@@ -1,15 +1,15 @@
 import logging
 
+from kabigon.application.source_applicability import parse_ptt_target
 from kabigon.domain.loader import Loader
 
 from .httpx import HttpxLoader
-from .url_match import ensure_host_in
 
 logger = logging.getLogger(__name__)
 
 
 def check_ptt_url(url: str) -> None:
-    ensure_host_in(url, ["www.ptt.cc"], loader_name="PttLoader", source_name="PTT")
+    parse_ptt_target(url)
 
 
 class PttLoader(Loader):

--- a/src/kabigon/loaders/reddit.py
+++ b/src/kabigon/loaders/reddit.py
@@ -9,20 +9,14 @@ import httpx
 from playwright.async_api import TimeoutError
 from playwright.async_api import async_playwright
 
+from kabigon.application.source_applicability import parse_reddit_target
 from kabigon.domain.errors import LoaderContentError
 from kabigon.domain.errors import LoaderTimeoutError
 from kabigon.domain.loader import Loader
 
-from .url_match import ensure_host_in
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
-
-REDDIT_DOMAINS = [
-    "reddit.com",
-    "www.reddit.com",
-    "old.reddit.com",
-]
 
 USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
@@ -38,7 +32,7 @@ def check_reddit_url(url: str) -> None:
     Raises:
         LoaderNotApplicableError: If URL is not from Reddit
     """
-    ensure_host_in(url, REDDIT_DOMAINS, loader_name="RedditLoader", source_name="Reddit")
+    parse_reddit_target(url)
 
 
 def convert_to_old_reddit(url: str) -> str:

--- a/src/kabigon/loaders/reel.py
+++ b/src/kabigon/loaders/reel.py
@@ -1,4 +1,4 @@
-from kabigon.domain.errors import LoaderNotApplicableError
+from kabigon.application.source_applicability import parse_reel_target
 from kabigon.domain.loader import Loader
 
 from .httpx import HttpxLoader
@@ -6,8 +6,7 @@ from .ytdlp import YtdlpLoader
 
 
 def check_reel_url(url: str) -> None:
-    if not url.startswith("https://www.instagram.com/reel"):
-        raise LoaderNotApplicableError("ReelLoader", url, "Not an Instagram Reel URL")
+    parse_reel_target(url)
 
 
 class ReelLoader(Loader):

--- a/tests/test_pipeline_catalog.py
+++ b/tests/test_pipeline_catalog.py
@@ -27,6 +27,13 @@ def test_match_pipeline_reddit() -> None:
     assert pipeline.targeted_loaders == ("reddit",)
 
 
+def test_match_pipeline_ptt() -> None:
+    pipeline = match_pipeline("https://www.ptt.cc/bbs/Gossiping/M.1746078381.A.FFC.html")
+
+    assert pipeline is not None
+    assert pipeline.name == "ptt"
+
+
 @pytest.mark.parametrize(
     "url",
     [
@@ -84,6 +91,21 @@ def test_match_pipeline_raw_github() -> None:
 
     assert pipeline is not None
     assert pipeline.name == "github"
+
+
+@pytest.mark.parametrize(
+    ("url", "pipeline_name"),
+    [
+        ("https://www.instagram.com/reel/CuA0XYZ1234/", "reel"),
+        ("https://www.bbc.com/news/articles/c70k29914q4o", "bbc"),
+        ("https://edition.cnn.com/2026/03/16/tech/example", "cnn"),
+    ],
+)
+def test_match_pipeline_remaining_source_applicability(url: str, pipeline_name: str) -> None:
+    pipeline = match_pipeline(url)
+
+    assert pipeline is not None
+    assert pipeline.name == pipeline_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Move PTT, Reddit, Reel, BBC, CNN, and OpenAI web applicability into the shared Source applicability module.
- Reuse shared parsing from the Pipeline catalog and each defensive loader path where applicable.
- Add Pipeline catalog regression coverage for the remaining source-specific pipelines.

## Verification
- uv run ruff check .
- uv run ty check .
- uv run pytest -v -s --cov=src tests