### PR TITLE
refactor: deepen planning and browser seams

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,7 @@ _Avoid_: route matcher, loader validation, URL guard
 
 - `docs/EARLY_LOAD_CHAIN.md` records the pre-routing fixed `Compose` load chain used around `v0.14.1` and earlier.
 - The **Load chain** owns ordered Loader attempts in current architecture.
+- The **Load chain** owns the default **Fallback loader** order; the Loader registry owns Loader factory wiring.
 
 ## Example dialogue
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ uv publish
 3. Export the class from `src/kabigon/loaders/__init__.py`.
 4. Register the loader in `src/kabigon/loader_registry.py`.
 5. Add a Pipeline catalog entry in `src/kabigon/pipelines/catalog.py` if the loader handles a specific source.
-6. Add or update Load chain and registry consistency tests when the Execution plan should change.
+6. Add or update Load chain and planning consistency tests when the Execution plan should change.
 7. Add Loader tests in `tests/loaders/`.
 
 ## License

--- a/src/kabigon/cli.py
+++ b/src/kabigon/cli.py
@@ -5,15 +5,37 @@ from typing import NoReturn
 
 import typer
 
+from kabigon import loader_registry
 from kabigon.api import load_url_sync
 from kabigon.core.loader import Loader
 from kabigon.load_chain import resolve_explicit_load_chain
-from kabigon.loader_registry import get_cli_loader_defs
+from kabigon.loader_registry import get_loader_description
+from kabigon.loader_registry import get_loader_factory
 
 LoaderFactory = Callable[[], Loader]
 LoaderDef = tuple[str, str, LoaderFactory]
 
-LOADER_DEFS: list[LoaderDef] = get_cli_loader_defs()
+CLI_VISIBLE_LOADERS = (
+    loader_registry.PLAYWRIGHT,
+    loader_registry.HTTPX,
+    loader_registry.BBC,
+    loader_registry.CNN,
+    loader_registry.FIRECRAWL,
+    loader_registry.YOUTUBE,
+    loader_registry.YOUTUBE_YTDLP,
+    loader_registry.YTDLP,
+    loader_registry.TWITTER,
+    loader_registry.TRUTHSOCIAL,
+    loader_registry.REDDIT,
+    loader_registry.PTT,
+    loader_registry.REEL,
+    loader_registry.GITHUB,
+    loader_registry.PDF,
+)
+
+LOADER_DEFS: list[LoaderDef] = [
+    (name, get_loader_description(name), get_loader_factory(name)) for name in CLI_VISIBLE_LOADERS
+]
 
 app = typer.Typer(add_completion=False)
 

--- a/src/kabigon/load_chain.py
+++ b/src/kabigon/load_chain.py
@@ -7,13 +7,13 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from kabigon import loader_registry
 from kabigon.core.errors import LoaderContentError
 from kabigon.core.errors import LoaderError
 from kabigon.core.errors import LoaderNotApplicableError
 from kabigon.core.errors import LoaderTimeoutError
 from kabigon.core.errors import MissingRequirementError
 from kabigon.core.loader import Loader
-from kabigon.loader_registry import DEFAULT_FALLBACK_LOADERS
 from kabigon.loader_registry import get_loader_factory
 from kabigon.pipelines.catalog import ContentType
 from kabigon.pipelines.catalog import FallbackPolicy
@@ -21,6 +21,22 @@ from kabigon.pipelines.catalog import match_pipeline
 
 LoaderFactory = Callable[[], Loader]
 _EMPTY_EXECUTION_PLAN = "Load chain execution plan cannot be empty."
+
+DEFAULT_FALLBACK_LOADERS = (
+    loader_registry.PTT,
+    loader_registry.TWITTER,
+    loader_registry.TRUTHSOCIAL,
+    loader_registry.REDDIT,
+    loader_registry.YOUTUBE,
+    loader_registry.REEL,
+    loader_registry.YOUTUBE_YTDLP,
+    loader_registry.PDF,
+    loader_registry.GITHUB,
+    loader_registry.BBC,
+    loader_registry.CNN,
+    loader_registry.PLAYWRIGHT_NETWORKIDLE,
+    loader_registry.PLAYWRIGHT_FAST,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/kabigon/loader_registry.py
+++ b/src/kabigon/loader_registry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from collections.abc import Sequence
 
 import kabigon.loaders as loaders
 from kabigon.core.loader import Loader
@@ -26,40 +25,6 @@ PLAYWRIGHT = "playwright"
 HTTPX = "httpx"
 FIRECRAWL = "firecrawl"
 YTDLP = "ytdlp"
-
-DEFAULT_FALLBACK_LOADERS = (
-    PTT,
-    TWITTER,
-    TRUTHSOCIAL,
-    REDDIT,
-    YOUTUBE,
-    REEL,
-    YOUTUBE_YTDLP,
-    PDF,
-    GITHUB,
-    BBC,
-    CNN,
-    PLAYWRIGHT_NETWORKIDLE,
-    PLAYWRIGHT_FAST,
-)
-
-CLI_VISIBLE_LOADERS = (
-    PLAYWRIGHT,
-    HTTPX,
-    BBC,
-    CNN,
-    FIRECRAWL,
-    YOUTUBE,
-    YOUTUBE_YTDLP,
-    YTDLP,
-    TWITTER,
-    TRUTHSOCIAL,
-    REDDIT,
-    PTT,
-    REEL,
-    GITHUB,
-    PDF,
-)
 
 LOADER_DEFS: tuple[LoaderDef, ...] = (
     (PTT, "Taiwan PTT forum posts", lambda: loaders.PttLoader()),
@@ -100,21 +65,13 @@ LOADER_DEFS: tuple[LoaderDef, ...] = (
 _LOADER_FACTORY_BY_NAME: dict[str, LoaderFactory] = {name: factory for name, _description, factory in LOADER_DEFS}
 _LOADER_DESCRIPTION_BY_NAME: dict[str, str] = {name: description for name, description, _factory in LOADER_DEFS}
 
-CLI_VISIBLE_LOADER_NAMES = CLI_VISIBLE_LOADERS
-
 
 def get_loader_factory(name: str) -> LoaderFactory:
     return _LOADER_FACTORY_BY_NAME[name]
 
 
-def get_loader_descriptions(names: Sequence[str]) -> list[tuple[str, str]]:
-    return [(name, _LOADER_DESCRIPTION_BY_NAME[name]) for name in names]
-
-
-def get_cli_loader_defs() -> list[LoaderDef]:
-    return [
-        (name, _LOADER_DESCRIPTION_BY_NAME[name], _LOADER_FACTORY_BY_NAME[name]) for name in CLI_VISIBLE_LOADER_NAMES
-    ]
+def get_loader_description(name: str) -> str:
+    return _LOADER_DESCRIPTION_BY_NAME[name]
 
 
 def list_loader_names() -> list[str]:
@@ -123,10 +80,7 @@ def list_loader_names() -> list[str]:
 
 __all__ = [
     "BBC",
-    "CLI_VISIBLE_LOADERS",
-    "CLI_VISIBLE_LOADER_NAMES",
     "CNN",
-    "DEFAULT_FALLBACK_LOADERS",
     "FIRECRAWL",
     "GITHUB",
     "HTTPX",
@@ -145,8 +99,7 @@ __all__ = [
     "YTDLP",
     "LoaderDef",
     "LoaderFactory",
-    "get_cli_loader_defs",
-    "get_loader_descriptions",
+    "get_loader_description",
     "get_loader_factory",
     "list_loader_names",
 ]

--- a/src/kabigon/loaders/bbc.py
+++ b/src/kabigon/loaders/bbc.py
@@ -16,4 +16,6 @@ class BBCLoader(Loader):
         self.headers = headers or DEFAULT_NEWS_ARTICLE_HEADERS
 
     async def load(self, url: str) -> str:
-        return await load_news_article(url, loader_name="BBCLoader", validate_url=check_bbc_url, headers=self.headers)
+        return await load_news_article(
+            url, loader_name="BBCLoader", validate_url=parse_bbc_target, headers=self.headers
+        )

--- a/src/kabigon/loaders/browser.py
+++ b/src/kabigon/loaders/browser.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from collections.abc import Callable
+from typing import Literal
+
+from playwright.async_api import Page
+from playwright.async_api import Request
+from playwright.async_api import Route
+from playwright.async_api import TimeoutError
+from playwright.async_api import async_playwright
+
+from kabigon.core.errors import LoaderTimeoutError
+
+BrowserPageHook = Callable[[Page], Awaitable[None]]
+BrowserContentExtractor = Callable[[Page], Awaitable[str]]
+BrowserWaitUntil = Literal["commit", "domcontentloaded", "load", "networkidle"]
+
+DEFAULT_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+DEFAULT_BLOCKED_RESOURCE_TYPES = frozenset({"font", "image", "media"})
+
+
+async def fetch_browser_html(
+    url: str,
+    *,
+    loader_name: str,
+    timeout_ms: float | None,
+    timeout_suggestion: str,
+    wait_until: BrowserWaitUntil | None = None,
+    user_agent: str | None = None,
+    browser_headless: bool = True,
+    block_resource_types: frozenset[str] = frozenset(),
+    after_goto: BrowserPageHook | None = None,
+    extract_content: BrowserContentExtractor | None = None,
+) -> str:
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=browser_headless)
+        context = None
+        try:
+            if user_agent is None:
+                context = await browser.new_context()
+            else:
+                context = await browser.new_context(user_agent=user_agent)
+            page = await context.new_page()
+
+            if block_resource_types:
+
+                async def route_handler(route: Route, request: Request) -> None:
+                    if request.resource_type in block_resource_types:
+                        await route.abort()
+                        return
+                    await route.continue_()
+
+                await page.route("**/*", route_handler)
+
+            try:
+                if wait_until is None:
+                    await page.goto(url, timeout=timeout_ms)
+                else:
+                    await page.goto(url, timeout=timeout_ms, wait_until=wait_until)
+            except TimeoutError as e:
+                timeout_seconds = (timeout_ms or 0) / 1000 if timeout_ms else 30
+                raise LoaderTimeoutError(loader_name, url, timeout_seconds, timeout_suggestion) from e
+
+            if after_goto is not None:
+                await after_goto(page)
+
+            if extract_content is not None:
+                return await extract_content(page)
+            return await page.content()
+        finally:
+            if context is not None:
+                await context.close()
+            await browser.close()
+
+
+__all__ = [
+    "DEFAULT_BLOCKED_RESOURCE_TYPES",
+    "DEFAULT_BROWSER_USER_AGENT",
+    "BrowserContentExtractor",
+    "BrowserPageHook",
+    "BrowserWaitUntil",
+    "fetch_browser_html",
+]

--- a/src/kabigon/loaders/cnn.py
+++ b/src/kabigon/loaders/cnn.py
@@ -16,4 +16,6 @@ class CNNLoader(Loader):
         self.headers = headers or DEFAULT_NEWS_ARTICLE_HEADERS
 
     async def load(self, url: str) -> str:
-        return await load_news_article(url, loader_name="CNNLoader", validate_url=check_cnn_url, headers=self.headers)
+        return await load_news_article(
+            url, loader_name="CNNLoader", validate_url=parse_cnn_target, headers=self.headers
+        )

--- a/src/kabigon/loaders/github.py
+++ b/src/kabigon/loaders/github.py
@@ -45,7 +45,7 @@ def extract_main_html(html: str) -> str:
 
 class GitHubLoader(Loader):
     async def load(self, url: str) -> str:
-        check_github_url(url)
+        parse_github_target(url)
         parsed = urlparse(url)
 
         if parsed.netloc == RAW_GITHUB_HOST or "/blob/" in parsed.path:

--- a/src/kabigon/loaders/playwright.py
+++ b/src/kabigon/loaders/playwright.py
@@ -1,12 +1,9 @@
 import logging
 from typing import Literal
 
-from playwright.async_api import TimeoutError
-from playwright.async_api import async_playwright
-
-from kabigon.core.errors import LoaderTimeoutError
 from kabigon.core.loader import Loader
 
+from .browser import fetch_browser_html
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
@@ -31,36 +28,17 @@ class PlaywrightLoader(Loader):
             self.wait_until,
         )
 
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(headless=self.browser_headless)
-            context = None
-            content = ""
-
-            try:
-                context = await browser.new_context()
-                page = await context.new_page()
-                if self.wait_until is None:
-                    await page.goto(url, timeout=self.timeout)
-                else:
-                    await page.goto(url, timeout=self.timeout, wait_until=self.wait_until)
-                logger.debug("[PlaywrightLoader] Successfully loaded page")
-            except TimeoutError as e:
-                timeout_seconds = (self.timeout or 0) / 1000 if self.timeout else 30
-                logger.warning("[PlaywrightLoader] Timeout after %ss: %s", timeout_seconds, url)
-                raise LoaderTimeoutError(
-                    "PlaywrightLoader",
-                    url,
-                    timeout_seconds,
-                    "The page took too long to load. Try increasing the timeout or using a faster wait_until option.",
-                ) from e
-            else:
-                content = await page.content()
-
-            finally:
-                if context is not None:
-                    await context.close()
-                await browser.close()
-
-            result = html_to_markdown(content)
-            logger.debug("[PlaywrightLoader] Successfully extracted content (%s chars)", len(result))
-            return result
+        content = await fetch_browser_html(
+            url,
+            loader_name="PlaywrightLoader",
+            timeout_ms=self.timeout,
+            timeout_suggestion=(
+                "The page took too long to load. Try increasing the timeout or using a faster wait_until option."
+            ),
+            wait_until=self.wait_until,
+            browser_headless=self.browser_headless,
+        )
+        logger.debug("[PlaywrightLoader] Successfully loaded page")
+        result = html_to_markdown(content)
+        logger.debug("[PlaywrightLoader] Successfully extracted content (%s chars)", len(result))
+        return result

--- a/src/kabigon/loaders/ptt.py
+++ b/src/kabigon/loaders/ptt.py
@@ -24,7 +24,7 @@ class PttLoader(Loader):
 
     async def load(self, url: str) -> str:
         logger.debug("[PttLoader] Processing URL: %s", url)
-        check_ptt_url(url)
+        parse_ptt_target(url)
 
         result = await self.httpx_loader.load(url)
         logger.debug("[PttLoader] Successfully loaded content (%s chars)", len(result))

--- a/src/kabigon/loaders/reddit.py
+++ b/src/kabigon/loaders/reddit.py
@@ -6,21 +6,18 @@ from urllib.parse import urlunparse
 from xml.etree import ElementTree as ET
 
 import httpx
-from playwright.async_api import TimeoutError
-from playwright.async_api import async_playwright
 
 from kabigon.core.errors import LoaderContentError
 from kabigon.core.errors import LoaderTimeoutError
 from kabigon.core.loader import Loader
 from kabigon.sources.applicability import parse_reddit_target
 
+from .browser import DEFAULT_BROWSER_USER_AGENT
+from .browser import fetch_browser_html
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
-
-USER_AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
-)
+USER_AGENT = DEFAULT_BROWSER_USER_AGENT
 
 
 def check_reddit_url(url: str) -> None:
@@ -273,27 +270,16 @@ class RedditLoader(Loader):
         old_reddit_url = convert_to_old_reddit(url)
         logger.debug("[RedditLoader] Converted to old Reddit: %s", old_reddit_url)
 
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(headless=True)
-            context = await browser.new_context(user_agent=USER_AGENT)
-            page = await context.new_page()
-
-            try:
-                await page.goto(old_reddit_url, timeout=self.timeout, wait_until="networkidle")
-                logger.debug("[RedditLoader] Page loaded successfully via old Reddit")
-            except TimeoutError as e:
-                await browser.close()
-                logger.warning("[RedditLoader] Timeout after %ss: %s", self.timeout / 1000, old_reddit_url)
-                raise LoaderTimeoutError(
-                    "RedditLoader",
-                    old_reddit_url,
-                    self.timeout / 1000,
-                    "Reddit pages can be slow to load. Try increasing the timeout.",
-                ) from e
-
-            content = await page.content()
-            await browser.close()
-            return html_to_markdown(content)
+        content = await fetch_browser_html(
+            old_reddit_url,
+            loader_name="RedditLoader",
+            timeout_ms=self.timeout,
+            timeout_suggestion="Reddit pages can be slow to load. Try increasing the timeout.",
+            wait_until="networkidle",
+            user_agent=DEFAULT_BROWSER_USER_AGENT,
+        )
+        logger.debug("[RedditLoader] Page loaded successfully via old Reddit")
+        return html_to_markdown(content)
 
     async def load(self, url: str) -> str:
         """Asynchronously load Reddit content from URL.
@@ -309,7 +295,7 @@ class RedditLoader(Loader):
             LoaderTimeoutError: If page loading times out
         """
         logger.debug("[RedditLoader] Processing URL: %s", url)
-        check_reddit_url(url)
+        parse_reddit_target(url)
         try:
             result = await self._load_via_json(url)
         except (LoaderContentError, LoaderTimeoutError) as json_error:

--- a/src/kabigon/loaders/reel.py
+++ b/src/kabigon/loaders/reel.py
@@ -15,7 +15,7 @@ class ReelLoader(Loader):
         self.ytdlp_loader = YtdlpLoader()
 
     async def load(self, url: str) -> str:
-        check_reel_url(url)
+        parse_reel_target(url)
 
         audio_content = await self.ytdlp_loader.load(url)
         html_content = await self.httpx_loader.load(url)

--- a/src/kabigon/loaders/truthsocial.py
+++ b/src/kabigon/loaders/truthsocial.py
@@ -1,23 +1,18 @@
 import logging
 from contextlib import suppress
-from typing import Literal
 
-from playwright.async_api import Request
-from playwright.async_api import Route
+from playwright.async_api import Page
 from playwright.async_api import TimeoutError
-from playwright.async_api import async_playwright
 
-from kabigon.core.errors import LoaderTimeoutError
 from kabigon.core.loader import Loader
 from kabigon.sources.applicability import parse_truthsocial_target
 
+from .browser import DEFAULT_BLOCKED_RESOURCE_TYPES
+from .browser import DEFAULT_BROWSER_USER_AGENT
+from .browser import fetch_browser_html
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
-
-USER_AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
-)
 
 
 def check_truthsocial_url(url: str) -> None:
@@ -61,44 +56,28 @@ class TruthSocialLoader(Loader):
             LoaderTimeoutError: If page loading times out
         """
         logger.debug("[TruthSocialLoader] Processing URL: %s", url)
-        check_truthsocial_url(url)
+        parse_truthsocial_target(url)
 
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(headless=True)
-            context = await browser.new_context(user_agent=USER_AGENT)
-            page = await context.new_page()
-            wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = "domcontentloaded"
+        async def wait_for_post_content(page: Page) -> None:
+            with suppress(TimeoutError):
+                await page.wait_for_selector(
+                    "article, .status, [data-testid='status'], [data-testid='post-content']",
+                    state="attached",
+                    timeout=min(self.timeout, 5_000),
+                )
 
-            async def route_handler(route: Route, request: Request) -> None:
-                if request.resource_type in {"image", "media", "font"}:
-                    await route.abort()
-                    return
-                await route.continue_()
+        content = await fetch_browser_html(
+            url,
+            loader_name="TruthSocialLoader",
+            timeout_ms=self.timeout,
+            timeout_suggestion="Truth Social pages require JavaScript and can be slow. Try increasing the timeout.",
+            wait_until="domcontentloaded",
+            user_agent=DEFAULT_BROWSER_USER_AGENT,
+            block_resource_types=DEFAULT_BLOCKED_RESOURCE_TYPES,
+            after_goto=wait_for_post_content,
+        )
+        logger.debug("[TruthSocialLoader] Page loaded successfully")
 
-            await page.route("**/*", route_handler)
-
-            try:
-                await page.goto(url, timeout=self.timeout, wait_until=wait_until)
-                with suppress(TimeoutError):
-                    await page.wait_for_selector(
-                        "article, .status, [data-testid='status'], [data-testid='post-content']",
-                        state="attached",
-                        timeout=min(self.timeout, 5_000),
-                    )
-                logger.debug("[TruthSocialLoader] Page loaded successfully")
-            except TimeoutError as e:
-                await browser.close()
-                logger.warning("[TruthSocialLoader] Timeout after %ss: %s", self.timeout / 1000, url)
-                raise LoaderTimeoutError(
-                    "TruthSocialLoader",
-                    url,
-                    self.timeout / 1000,
-                    "Truth Social pages require JavaScript and can be slow. Try increasing the timeout.",
-                ) from e
-
-            content = await page.content()
-            await browser.close()
-
-            result = html_to_markdown(content)
-            logger.debug("[TruthSocialLoader] Successfully extracted content (%s chars)", len(result))
-            return result
+        result = html_to_markdown(content)
+        logger.debug("[TruthSocialLoader] Successfully extracted content (%s chars)", len(result))
+        return result

--- a/src/kabigon/loaders/twitter.py
+++ b/src/kabigon/loaders/twitter.py
@@ -4,22 +4,17 @@ import logging
 
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import Page
-from playwright.async_api import Request
-from playwright.async_api import Route
 from playwright.async_api import TimeoutError
-from playwright.async_api import async_playwright
 
-from kabigon.core.errors import LoaderTimeoutError
 from kabigon.core.loader import Loader
 from kabigon.sources.applicability import parse_twitter_target
 
+from .browser import DEFAULT_BLOCKED_RESOURCE_TYPES
+from .browser import DEFAULT_BROWSER_USER_AGENT
+from .browser import fetch_browser_html
 from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
-USER_AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
-)
-
 TWEET_READY_SELECTORS = [
     'article [data-testid="tweetText"]',
     'article [data-testid="tweet"]',
@@ -65,36 +60,12 @@ class TwitterLoader(Loader):
 
     async def load(self, url: str) -> str:
         logger.debug("[TwitterLoader] Processing URL: %s", url)
-        check_x_url(url)
+        parse_twitter_target(url)
 
         url = replace_domain(url)
         logger.debug("[TwitterLoader] Normalized URL: %s", url)
 
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(headless=True)
-            context = await browser.new_context(user_agent=USER_AGENT)
-            page = await context.new_page()
-
-            async def route_handler(route: Route, request: Request) -> None:
-                if request.resource_type in {"image", "media", "font"}:
-                    await route.abort()
-                    return
-                await route.continue_()
-
-            await page.route("**/*", route_handler)
-
-            try:
-                await page.goto(url, timeout=self.timeout, wait_until="domcontentloaded")
-            except TimeoutError as e:
-                await browser.close()
-                logger.warning("[TwitterLoader] Timeout during page load: %s", e)
-                raise LoaderTimeoutError(
-                    "TwitterLoader",
-                    url,
-                    self.timeout / 1000,
-                    "Twitter/X pages can be slow. Try increasing the timeout or check if the page requires login.",
-                ) from e
-
+        async def wait_for_tweet(page: Page) -> None:
             with contextlib.suppress(TimeoutError):
                 await self._wait_for_any_selector(
                     page,
@@ -102,6 +73,7 @@ class TwitterLoader(Loader):
                     timeout_ms=min(self.timeout or self.wait_for_tweet_timeout, self.wait_for_tweet_timeout),
                 )
 
+        async def extract_tweet_content(page: Page) -> str:
             try:
                 tweet_articles = page.locator("article").filter(has=page.locator('[data-testid="tweetText"]'))
                 if await tweet_articles.count() > 0:
@@ -113,8 +85,21 @@ class TwitterLoader(Loader):
             except (PlaywrightError, TimeoutError):
                 content = await page.content()
                 logger.debug("[TwitterLoader] Fallback to full page content after error")
+            return content
 
-            await browser.close()
-            result = html_to_markdown(content)
-            logger.debug("[TwitterLoader] Successfully converted to markdown (%s chars)", len(result))
-            return result
+        content = await fetch_browser_html(
+            url,
+            loader_name="TwitterLoader",
+            timeout_ms=self.timeout,
+            timeout_suggestion=(
+                "Twitter/X pages can be slow. Try increasing the timeout or check if the page requires login."
+            ),
+            wait_until="domcontentloaded",
+            user_agent=DEFAULT_BROWSER_USER_AGENT,
+            block_resource_types=DEFAULT_BLOCKED_RESOURCE_TYPES,
+            after_goto=wait_for_tweet,
+            extract_content=extract_tweet_content,
+        )
+        result = html_to_markdown(content)
+        logger.debug("[TwitterLoader] Successfully converted to markdown (%s chars)", len(result))
+        return result

--- a/src/kabigon/pipelines/catalog.py
+++ b/src/kabigon/pipelines/catalog.py
@@ -49,50 +49,6 @@ class _PipelineEntry:
     matches: Matcher
 
 
-def _is_ptt_url(url: str) -> bool:
-    return is_ptt_url(url)
-
-
-def _is_twitter_url(url: str) -> bool:
-    return is_twitter_url(url)
-
-
-def _is_truthsocial_url(url: str) -> bool:
-    return is_truthsocial_url(url)
-
-
-def _is_reddit_url(url: str) -> bool:
-    return is_reddit_url(url)
-
-
-def _is_youtube_url(url: str) -> bool:
-    return is_youtube_video_url(url)
-
-
-def _is_reel_url(url: str) -> bool:
-    return is_reel_url(url)
-
-
-def _is_github_url(url: str) -> bool:
-    return is_github_url(url)
-
-
-def _is_bbc_url(url: str) -> bool:
-    return is_bbc_url(url)
-
-
-def _is_cnn_url(url: str) -> bool:
-    return is_cnn_url(url)
-
-
-def _is_openai_web_url(url: str) -> bool:
-    return is_openai_web_url(url)
-
-
-def _is_pdf_url(url: str) -> bool:
-    return is_pdf_target(url)
-
-
 _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
     _PipelineEntry(
         pipeline=Pipeline(
@@ -100,7 +56,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.SOCIAL_POST,
             targeted_loaders=(loader_names.PTT,),
         ),
-        matches=_is_ptt_url,
+        matches=is_ptt_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -108,7 +64,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.SOCIAL_POST,
             targeted_loaders=(loader_names.TWITTER,),
         ),
-        matches=_is_twitter_url,
+        matches=is_twitter_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -116,7 +72,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.SOCIAL_POST,
             targeted_loaders=(loader_names.TRUTHSOCIAL,),
         ),
-        matches=_is_truthsocial_url,
+        matches=is_truthsocial_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -124,7 +80,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.SOCIAL_POST,
             targeted_loaders=(loader_names.REDDIT,),
         ),
-        matches=_is_reddit_url,
+        matches=is_reddit_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -132,7 +88,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.YOUTUBE_VIDEO,
             targeted_loaders=(loader_names.YOUTUBE, loader_names.YOUTUBE_YTDLP),
         ),
-        matches=_is_youtube_url,
+        matches=is_youtube_video_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -140,7 +96,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.SOCIAL_POST,
             targeted_loaders=(loader_names.REEL,),
         ),
-        matches=_is_reel_url,
+        matches=is_reel_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -148,7 +104,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.CODE_CONTENT,
             targeted_loaders=(loader_names.GITHUB,),
         ),
-        matches=_is_github_url,
+        matches=is_github_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -156,7 +112,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.NEWS_ARTICLE,
             targeted_loaders=(loader_names.BBC,),
         ),
-        matches=_is_bbc_url,
+        matches=is_bbc_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -164,7 +120,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.NEWS_ARTICLE,
             targeted_loaders=(loader_names.CNN,),
         ),
-        matches=_is_cnn_url,
+        matches=is_cnn_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -174,7 +130,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             requirements=("FIRECRAWL_API_KEY",),
             fallback_policy=FallbackPolicy.NO_FALLBACK,
         ),
-        matches=_is_openai_web_url,
+        matches=is_openai_web_url,
     ),
     _PipelineEntry(
         pipeline=Pipeline(
@@ -182,7 +138,7 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             content_type=ContentType.DOCUMENT_PDF,
             targeted_loaders=(loader_names.PDF,),
         ),
-        matches=_is_pdf_url,
+        matches=is_pdf_target,
     ),
 )
 

--- a/tests/loaders/test_browser.py
+++ b/tests/loaders/test_browser.py
@@ -1,0 +1,169 @@
+import asyncio
+
+import pytest
+from playwright.async_api import TimeoutError
+
+from kabigon.core.errors import LoaderTimeoutError
+from kabigon.loaders import browser
+
+
+class FakeRequest:
+    def __init__(self, resource_type: str) -> None:
+        self.resource_type = resource_type
+
+
+class FakeRoute:
+    def __init__(self) -> None:
+        self.aborted = False
+        self.continued = False
+
+    async def abort(self) -> None:
+        self.aborted = True
+
+    async def continue_(self) -> None:
+        self.continued = True
+
+
+class FakePage:
+    def __init__(self, raise_timeout: bool = False) -> None:
+        self.raise_timeout = raise_timeout
+        self.route_pattern = ""
+        self.route_handler = None
+        self.goto_timeout = 0.0
+        self.goto_wait_until = ""
+
+    async def route(self, pattern: str, handler) -> None:
+        self.route_pattern = pattern
+        self.route_handler = handler
+
+    async def goto(self, url: str, **kwargs) -> None:
+        if self.raise_timeout:
+            raise TimeoutError("timeout")
+        self.goto_timeout = kwargs["timeout"]
+        self.goto_wait_until = kwargs.get("wait_until", "")
+
+    async def content(self) -> str:
+        return "<html><body>content</body></html>"
+
+
+class FakeContext:
+    def __init__(self, page: FakePage) -> None:
+        self.page = page
+        self.closed = False
+
+    async def new_page(self) -> FakePage:
+        return self.page
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeBrowser:
+    def __init__(self, context: FakeContext) -> None:
+        self.context = context
+        self.closed = False
+        self.user_agent = None
+
+    async def new_context(self, **kwargs) -> FakeContext:
+        self.user_agent = kwargs.get("user_agent")
+        return self.context
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeChromium:
+    def __init__(self, browser_: FakeBrowser) -> None:
+        self.browser = browser_
+        self.headless = None
+
+    async def launch(self, headless: bool) -> FakeBrowser:
+        self.headless = headless
+        return self.browser
+
+
+class FakePlaywright:
+    def __init__(self, chromium: FakeChromium) -> None:
+        self.chromium = chromium
+
+
+class FakePlaywrightContextManager:
+    def __init__(self, playwright: FakePlaywright) -> None:
+        self.playwright = playwright
+
+    async def __aenter__(self) -> FakePlaywright:
+        return self.playwright
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+def _set_fake_playwright(monkeypatch: pytest.MonkeyPatch, page: FakePage) -> tuple[FakeBrowser, FakeChromium]:
+    context = FakeContext(page)
+    fake_browser = FakeBrowser(context)
+    chromium = FakeChromium(fake_browser)
+    manager = FakePlaywrightContextManager(FakePlaywright(chromium))
+    monkeypatch.setattr(browser, "async_playwright", lambda: manager)
+    return fake_browser, chromium
+
+
+def test_fetch_browser_html_applies_navigation_options_and_closes_resources(monkeypatch: pytest.MonkeyPatch) -> None:
+    page = FakePage()
+    fake_browser, chromium = _set_fake_playwright(monkeypatch, page)
+
+    html = asyncio.run(
+        browser.fetch_browser_html(
+            "https://example.com",
+            loader_name="TestLoader",
+            timeout_ms=10_000,
+            timeout_suggestion="try again",
+            wait_until="domcontentloaded",
+            user_agent="test-agent",
+            browser_headless=False,
+        )
+    )
+
+    assert html == "<html><body>content</body></html>"
+    assert chromium.headless is False
+    assert fake_browser.user_agent == "test-agent"
+    assert page.goto_timeout == 10_000
+    assert page.goto_wait_until == "domcontentloaded"
+    assert fake_browser.context.closed is True
+    assert fake_browser.closed is True
+
+
+def test_fetch_browser_html_filters_blocked_resources(monkeypatch: pytest.MonkeyPatch) -> None:
+    page = FakePage()
+    _set_fake_playwright(monkeypatch, page)
+
+    asyncio.run(
+        browser.fetch_browser_html(
+            "https://example.com",
+            loader_name="TestLoader",
+            timeout_ms=10_000,
+            timeout_suggestion="try again",
+            block_resource_types=frozenset({"image"}),
+        )
+    )
+
+    assert page.route_handler is not None
+    image_route = FakeRoute()
+    script_route = FakeRoute()
+    asyncio.run(page.route_handler(image_route, FakeRequest("image")))
+    asyncio.run(page.route_handler(script_route, FakeRequest("script")))
+    assert image_route.aborted is True
+    assert script_route.continued is True
+
+
+def test_fetch_browser_html_maps_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_fake_playwright(monkeypatch, FakePage(raise_timeout=True))
+
+    with pytest.raises(LoaderTimeoutError, match=r"timed out after 1\.0s"):
+        asyncio.run(
+            browser.fetch_browser_html(
+                "https://example.com",
+                loader_name="TestLoader",
+                timeout_ms=1_000,
+                timeout_suggestion="try again",
+            )
+        )

--- a/tests/loaders/test_truthsocial.py
+++ b/tests/loaders/test_truthsocial.py
@@ -1,8 +1,8 @@
 import pytest
-from playwright.async_api import TimeoutError
 
 from kabigon.core.errors import LoaderNotApplicableError
-from kabigon.core.errors import LoaderTimeoutError
+from kabigon.loaders.browser import DEFAULT_BLOCKED_RESOURCE_TYPES
+from kabigon.loaders.browser import DEFAULT_BROWSER_USER_AGENT
 from kabigon.loaders.truthsocial import TruthSocialLoader
 from kabigon.loaders.truthsocial import check_truthsocial_url
 
@@ -45,132 +45,34 @@ def test_truthsocial_loader_custom_timeout() -> None:
     assert loader.timeout == 30_000
 
 
-class FakeRequest:
-    def __init__(self, resource_type: str) -> None:
-        self.resource_type = resource_type
-
-
-class FakeRoute:
-    def __init__(self) -> None:
-        self.aborted = False
-        self.continued = False
-
-    async def abort(self) -> None:
-        self.aborted = True
-
-    async def continue_(self) -> None:
-        self.continued = True
-
-
 class FakePage:
-    def __init__(self, raise_timeout: bool = False) -> None:
-        self.raise_timeout = raise_timeout
-        self.route_pattern = ""
-        self.route_handler = None
-        self.goto_wait_until = ""
-        self.goto_timeout = 0.0
+    def __init__(self) -> None:
         self.selector_timeout = 0.0
-
-    async def route(self, pattern: str, handler) -> None:
-        self.route_pattern = pattern
-        self.route_handler = handler
-
-    async def goto(self, url: str, **kwargs) -> None:
-        if self.raise_timeout:
-            raise TimeoutError("timeout")
-        self.goto_timeout = kwargs["timeout"]
-        self.goto_wait_until = kwargs["wait_until"]
 
     async def wait_for_selector(self, selector: str, state: str, **kwargs) -> None:
         self.selector_timeout = kwargs["timeout"]
 
-    async def content(self) -> str:
+
+def test_truthsocial_loader_uses_browser_retrieval_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    page = FakePage()
+
+    async def fake_fetch_browser_html(url: str, **kwargs) -> str:
+        captured["url"] = url
+        captured.update(kwargs)
+        await kwargs["after_goto"](page)
         return "<html><body><article>truth</article></body></html>"
 
+    monkeypatch.setattr("kabigon.loaders.truthsocial.fetch_browser_html", fake_fetch_browser_html)
 
-class FakeContext:
-    def __init__(self, page: FakePage) -> None:
-        self._page = page
-
-    async def new_page(self) -> FakePage:
-        return self._page
-
-
-class FakeBrowser:
-    def __init__(self, context: FakeContext) -> None:
-        self._context = context
-
-    async def new_context(self, user_agent: str) -> FakeContext:
-        return self._context
-
-    async def close(self) -> None:
-        return None
-
-
-class FakeChromium:
-    def __init__(self, browser: FakeBrowser) -> None:
-        self._browser = browser
-
-    async def launch(self, headless: bool) -> FakeBrowser:
-        return self._browser
-
-
-class FakePlaywright:
-    def __init__(self, chromium: FakeChromium) -> None:
-        self.chromium = chromium
-
-
-class FakePlaywrightContextManager:
-    def __init__(self, playwright: FakePlaywright) -> None:
-        self._playwright = playwright
-
-    async def __aenter__(self) -> FakePlaywright:
-        return self._playwright
-
-    async def __aexit__(self, exc_type, exc, tb) -> bool:
-        return False
-
-
-def _set_fake_playwright(monkeypatch: pytest.MonkeyPatch, page: FakePage) -> FakePage:
-    context = FakeContext(page)
-    browser = FakeBrowser(context)
-    chromium = FakeChromium(browser)
-    playwright = FakePlaywright(chromium)
-    manager = FakePlaywrightContextManager(playwright)
-    monkeypatch.setattr("kabigon.loaders.truthsocial.async_playwright", lambda: manager)
-    return page
-
-
-def test_truthsocial_loader_uses_fast_navigation_strategy(monkeypatch: pytest.MonkeyPatch) -> None:
-    page = _set_fake_playwright(monkeypatch, FakePage())
     loader = TruthSocialLoader(timeout=10_000)
     result = loader.load_sync("https://truthsocial.com/@realDonaldTrump/posts/123456")
 
-    assert page.route_pattern == "**/*"
-    assert page.goto_wait_until == "domcontentloaded"
-    assert page.goto_timeout == 10_000
+    assert captured["url"] == "https://truthsocial.com/@realDonaldTrump/posts/123456"
+    assert captured["loader_name"] == "TruthSocialLoader"
+    assert captured["timeout_ms"] == 10_000
+    assert captured["wait_until"] == "domcontentloaded"
+    assert captured["user_agent"] == DEFAULT_BROWSER_USER_AGENT
+    assert captured["block_resource_types"] == DEFAULT_BLOCKED_RESOURCE_TYPES
     assert page.selector_timeout == 5_000
     assert "truth" in result
-
-
-def test_truthsocial_loader_filters_heavy_resources(monkeypatch: pytest.MonkeyPatch) -> None:
-    import asyncio
-
-    page = _set_fake_playwright(monkeypatch, FakePage())
-    loader = TruthSocialLoader(timeout=10_000)
-    loader.load_sync("https://truthsocial.com/@realDonaldTrump/posts/123456")
-
-    assert page.route_handler is not None
-    image_route = FakeRoute()
-    script_route = FakeRoute()
-    asyncio.run(page.route_handler(image_route, FakeRequest("image")))
-    asyncio.run(page.route_handler(script_route, FakeRequest("script")))
-    assert image_route.aborted is True
-    assert script_route.continued is True
-
-
-def test_truthsocial_loader_timeout_maps_to_loader_timeout_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_fake_playwright(monkeypatch, FakePage(raise_timeout=True))
-    loader = TruthSocialLoader(timeout=1_000)
-    with pytest.raises(LoaderTimeoutError, match=r"timed out after 1\.0s"):
-        loader.load_sync("https://truthsocial.com/@realDonaldTrump/posts/123456")


### PR DESCRIPTION
## Summary
- Move default Fallback loader order into the Load chain so Execution plan planning stays with the runnable/explainable retrieval Seam.
- Narrow the Loader registry back to Loader factory wiring and metadata, with CLI presentation order owned locally by the CLI Adapter.
- Add a browser retrieval Adapter that owns Playwright lifecycle, resource filtering, timeout mapping, and HTML retrieval for browser-based Loaders.
- Point Pipeline catalog matchers and Loader implementations directly at Source applicability parsers where compatibility wrappers are not needed internally.

## Verification
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run ty check .`
- `uv run pytest -v -s --cov=src tests`

## Result
- `169 passed`