### PR TITLE
refactor: defer load chain loader construction

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -8,6 +8,7 @@
 - For local example runs, execute the user's exact command first and only add env overrides (for example `UV_CACHE_DIR`) after reproducing a concrete failure.
 - Reddit RSS fallback can return 403 when using browser-like request headers; fetch RSS with default httpx headers.
 - Treat CLI `--loader` and direct `kabigon.loaders.*` usage as advanced escape hatches; the preferred public interface is automatic Pipeline planning through `kabigon <url>` / `kabigon.load_url(url)`.
+- Keep Load chain Loader construction lazy; do not let later Fallback loader constructors run before earlier Loader attempts fail.
 
 ## TASTE
 

--- a/src/kabigon/load_chain.py
+++ b/src/kabigon/load_chain.py
@@ -65,13 +65,14 @@ class LoadChainExplanation:
 
 @dataclass(frozen=True)
 class LoadChain:
-    loaders: tuple[Loader, ...]
+    get_factory: Callable[[str], LoaderFactory]
     explanation: LoadChainExplanation
 
     async def load(self) -> str:
         errors: list[str] = []
 
-        for loader in self.loaders:
+        for loader_name in self.explanation.execution_plan:
+            loader = self.get_factory(loader_name)()
             loader_name = loader.__class__.__name__
             logger.debug("[%s] Attempting to load URL: %s", loader_name, self.explanation.url)
 
@@ -138,16 +139,6 @@ def _ensure_requirements(explanation: LoadChainExplanation) -> None:
     raise MissingRequirementError(explanation.missing_requirements)
 
 
-def _build_loaders(
-    loader_names: tuple[str, ...],
-    get_factory: Callable[[str], LoaderFactory] = get_loader_factory,
-) -> tuple[Loader, ...]:
-    if not loader_names:
-        raise ValueError(_EMPTY_EXECUTION_PLAN)
-
-    return tuple(get_factory(name)() for name in loader_names)
-
-
 def explain_load_chain(url: str) -> LoadChainExplanation:
     pipeline = match_pipeline(url)
 
@@ -180,7 +171,7 @@ def explain_load_chain(url: str) -> LoadChainExplanation:
 def resolve_load_chain(url: str) -> LoadChain:
     explanation = explain_load_chain(url)
     _ensure_requirements(explanation)
-    return LoadChain(loaders=_build_loaders(explanation.execution_plan), explanation=explanation)
+    return LoadChain(get_factory=get_loader_factory, explanation=explanation)
 
 
 def resolve_explicit_load_chain(
@@ -196,7 +187,9 @@ def resolve_explicit_load_chain(
         targeted_loaders=(),
         execution_plan=execution_plan,
     )
-    return LoadChain(loaders=_build_loaders(execution_plan, get_factory), explanation=explanation)
+    if not execution_plan:
+        raise ValueError(_EMPTY_EXECUTION_PLAN)
+    return LoadChain(get_factory=get_factory, explanation=explanation)
 
 
 __all__ = [

--- a/tests/test_load_chain.py
+++ b/tests/test_load_chain.py
@@ -10,7 +10,6 @@ from kabigon.load_chain import DEFAULT_FALLBACK_LOADERS
 from kabigon.load_chain import explain_load_chain
 from kabigon.load_chain import resolve_explicit_load_chain
 from kabigon.load_chain import resolve_load_chain
-from kabigon.loaders.firecrawl import FirecrawlLoader
 from kabigon.pipelines.catalog import ContentType
 
 
@@ -70,8 +69,6 @@ def test_load_chain_for_no_fallback_pipeline_builds_single_loader(monkeypatch) -
 
     chain = resolve_load_chain("https://openai.com/pricing")
 
-    assert len(chain.loaders) == 1
-    assert isinstance(chain.loaders[0], FirecrawlLoader)
     assert chain.explanation.pipeline == "openai_web"
     assert chain.explanation.execution_plan == ("firecrawl",)
     assert chain.explanation.requirements == ("FIRECRAWL_API_KEY",)
@@ -93,6 +90,21 @@ def test_explicit_load_chain_uses_shared_attempt_runtime() -> None:
 
     assert chain.explanation.execution_plan == ("empty", "success")
     assert chain.load_sync() == "loaded https://example.com"
+
+
+def test_load_chain_builds_loaders_only_when_attempted() -> None:
+    built: list[str] = []
+
+    def factory(name: str) -> type[Loader]:
+        built.append(name)
+        if name == "success":
+            return SuccessLoader
+        raise AssertionError(f"unexpected loader build: {name}")
+
+    chain = resolve_explicit_load_chain("https://example.com", ("success", "heavy-fallback"), factory)
+
+    assert chain.load_sync() == "loaded https://example.com"
+    assert built == ["success"]
 
 
 def test_load_chain_records_failed_attempt_details() -> None:


### PR DESCRIPTION
## Summary
- Construct Load chain Loaders lazily as each Execution plan attempt runs.
- Keep later Fallback loader constructor side effects from blocking earlier successful Loader attempts.
- Update Load chain tests to assert the lazy construction behavior and document the gotcha in MEMORY.md.

## Verification
- `uv run ruff format src/kabigon/load_chain.py tests/test_load_chain.py`
- `uv run ruff check src/kabigon/load_chain.py tests/test_load_chain.py`
- `uv run pytest -v -s tests/test_load_chain.py`