### PR TITLE
refactor: defer heavy loader setup

### DIFF
--- a/src/kabigon/load_chain.py
+++ b/src/kabigon/load_chain.py
@@ -71,12 +71,12 @@ class LoadChain:
     async def load(self) -> str:
         errors: list[str] = []
 
-        for loader_name in self.explanation.execution_plan:
-            loader = self.get_factory(loader_name)()
-            loader_name = loader.__class__.__name__
-            logger.debug("[%s] Attempting to load URL: %s", loader_name, self.explanation.url)
-
+        for planned_loader_name in self.explanation.execution_plan:
+            loader_name = planned_loader_name
             try:
+                loader = self.get_factory(planned_loader_name)()
+                loader_name = loader.__class__.__name__
+                logger.debug("[%s] Attempting to load URL: %s", loader_name, self.explanation.url)
                 result = await loader.load(self.explanation.url)
             except LoaderNotApplicableError as e:
                 logger.debug("[%s] Not applicable: %s", loader_name, e.reason)

--- a/src/kabigon/loaders/reel.py
+++ b/src/kabigon/loaders/reel.py
@@ -1,8 +1,12 @@
+from collections.abc import Callable
+
 from kabigon.core.loader import Loader
 from kabigon.sources.applicability import parse_reel_target
 
 from .httpx import HttpxLoader
 from .ytdlp import YtdlpLoader
+
+type LoaderFactory = Callable[[], Loader]
 
 
 def check_reel_url(url: str) -> None:
@@ -10,14 +14,18 @@ def check_reel_url(url: str) -> None:
 
 
 class ReelLoader(Loader):
-    def __init__(self) -> None:
-        self.httpx_loader = HttpxLoader()
-        self.ytdlp_loader = YtdlpLoader()
+    def __init__(
+        self,
+        ytdlp_loader_factory: LoaderFactory = YtdlpLoader,
+        httpx_loader_factory: LoaderFactory = HttpxLoader,
+    ) -> None:
+        self.ytdlp_loader_factory = ytdlp_loader_factory
+        self.httpx_loader_factory = httpx_loader_factory
 
     async def load(self, url: str) -> str:
         parse_reel_target(url)
 
-        audio_content = await self.ytdlp_loader.load(url)
-        html_content = await self.httpx_loader.load(url)
+        audio_content = await self.ytdlp_loader_factory().load(url)
+        html_content = await self.httpx_loader_factory().load(url)
 
         return f"{audio_content}\n\n{html_content}"

--- a/src/kabigon/loaders/youtube_ytdlp.py
+++ b/src/kabigon/loaders/youtube_ytdlp.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Callable
 
 from kabigon.core.errors import LoaderNotApplicableError
 from kabigon.core.loader import Loader
@@ -10,17 +11,19 @@ from .youtube import VideoIDError
 from .youtube import parse_video_id
 from .ytdlp import YtdlpLoader
 
+type LoaderFactory = Callable[[], Loader]
+
 
 class YoutubeYtdlpLoader(Loader):
-    def __init__(self) -> None:
-        self.ytdlp_loader = YtdlpLoader()
+    def __init__(self, ytdlp_loader_factory: LoaderFactory = YtdlpLoader) -> None:
+        self.ytdlp_loader_factory = ytdlp_loader_factory
 
     def load_sync(self, url: str) -> str:
         try:
             parse_video_id(url)
         except (UnsupportedURLSchemeError, UnsupportedURLNetlocError, NoVideoIDFoundError, VideoIDError) as e:
             raise LoaderNotApplicableError("YoutubeYtdlpLoader", url, str(e)) from e
-        return self.ytdlp_loader.load_sync(url)
+        return self.ytdlp_loader_factory().load_sync(url)
 
     async def load(self, url: str) -> str:
         return await asyncio.to_thread(self.load_sync, url)

--- a/tests/loaders/test_reel.py
+++ b/tests/loaders/test_reel.py
@@ -1,0 +1,20 @@
+import pytest
+
+from kabigon.core.errors import LoaderNotApplicableError
+from kabigon.core.loader import Loader
+from kabigon.loaders.reel import ReelLoader
+
+
+class UnexpectedLoader(Loader):
+    def __init__(self) -> None:
+        raise AssertionError("heavy loader should not be built")
+
+    async def load(self, url: str) -> str:
+        return "should not load"
+
+
+def test_reel_loader_checks_source_applicability_before_heavy_setup() -> None:
+    loader = ReelLoader(ytdlp_loader_factory=UnexpectedLoader, httpx_loader_factory=UnexpectedLoader)
+
+    with pytest.raises(LoaderNotApplicableError):
+        loader.load_sync("https://example.com/not-a-reel")

--- a/tests/loaders/test_youtube_ytdlp.py
+++ b/tests/loaders/test_youtube_ytdlp.py
@@ -1,0 +1,20 @@
+import pytest
+
+from kabigon.core.errors import LoaderNotApplicableError
+from kabigon.core.loader import Loader
+from kabigon.loaders.youtube_ytdlp import YoutubeYtdlpLoader
+
+
+class UnexpectedLoader(Loader):
+    def __init__(self) -> None:
+        raise AssertionError("heavy loader should not be built")
+
+    async def load(self, url: str) -> str:
+        return "should not load"
+
+
+def test_youtube_ytdlp_checks_source_applicability_before_heavy_setup() -> None:
+    loader = YoutubeYtdlpLoader(ytdlp_loader_factory=UnexpectedLoader)
+
+    with pytest.raises(LoaderNotApplicableError):
+        loader.load_sync("https://example.com/not-youtube")

--- a/tests/test_load_chain.py
+++ b/tests/test_load_chain.py
@@ -38,6 +38,14 @@ class ContentFailLoader(Loader):
         raise LoaderContentError("ContentFailLoader", url, "parse failed")
 
 
+class ConstructorFailLoader(Loader):
+    def __init__(self) -> None:
+        raise RuntimeError("constructor failed")
+
+    async def load(self, url: str) -> str:
+        return "should not load"
+
+
 def test_load_chain_explains_youtube_decision() -> None:
     explanation = explain_load_chain("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
 
@@ -105,6 +113,16 @@ def test_load_chain_builds_loaders_only_when_attempted() -> None:
 
     assert chain.load_sync() == "loaded https://example.com"
     assert built == ["success"]
+
+
+def test_load_chain_records_constructor_failure_and_continues() -> None:
+    chain = resolve_explicit_load_chain(
+        "https://example.com",
+        ("constructor-fail", "success"),
+        {"constructor-fail": ConstructorFailLoader, "success": SuccessLoader}.__getitem__,
+    )
+
+    assert chain.load_sync() == "loaded https://example.com"
 
 
 def test_load_chain_records_failed_attempt_details() -> None:


### PR DESCRIPTION
## Summary
- Treat Loader factory/constructor failures as Load chain attempt failures so later Loaders can still run.
- Defer Reel and YouTube yt-dlp heavy setup until after Source applicability passes.
- Add tests for constructor failure continuation and non-applicable URLs avoiding heavy internal Loader construction.

## Verification
- `uv run ruff format src/kabigon/load_chain.py src/kabigon/loaders/reel.py src/kabigon/loaders/youtube_ytdlp.py tests/test_load_chain.py tests/loaders/test_reel.py tests/loaders/test_youtube_ytdlp.py`
- `uv run ruff check src/kabigon/load_chain.py src/kabigon/loaders/reel.py src/kabigon/loaders/youtube_ytdlp.py tests/test_load_chain.py tests/loaders/test_reel.py tests/loaders/test_youtube_ytdlp.py`
- `uv run pytest -v -s tests/test_load_chain.py tests/loaders/test_reel.py tests/loaders/test_youtube_ytdlp.py`