### PR TITLE
refactor: centralize loader applicability semantics

### DIFF
--- a/skills/kabigon/SKILL.md
+++ b/skills/kabigon/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: kabigon
-description: Load URL content as text or markdown with kabigon. Use this for extracting content from YouTube videos, social posts, news articles, PDFs, GitHub files, generic web pages, and audio/video URLs.
+description: Load URL content as text or markdown with kabigon. Use this for extracting content from YouTube videos, social posts, news articles, PDFs, GitHub files, generic web pages, and audio/video URLs through kabigon's automatic Pipeline planning.
 ---
 
 ## How to load URL content
 
+Use the automatic path unless you are debugging or intentionally comparing Loaders. Kabigon matches the URL to a source-specific Pipeline, builds an Execution plan from Targeted loaders plus allowed Fallback loaders, and returns the first successful Loader result.
+
 ```shell
-# Prefer automatic pipeline planning. Kabigon selects targeted loaders first,
-# then falls back to generic loaders when policy allows it.
+# CLI usage
 uvx kabigon https://www.youtube.com/watch?v=dQw4w9WgXcQ
 uvx kabigon https://x.com/howie_serious/status/1917768568135115147
 uvx kabigon https://reddit.com/r/python/comments/xyz/...
@@ -15,14 +16,35 @@ uvx kabigon https://github.com/user/repo/blob/main/README.md
 uvx kabigon https://example.com/document.pdf
 ```
 
+```python
+import kabigon
+
+text = kabigon.load_url_sync("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+```
+
+```python
+import asyncio
+import kabigon
+
+text = await kabigon.load_url("https://x.com/user/status/123")
+```
+
 ```shell
 # List supported loader names.
 uvx kabigon --list
 ```
 
+```python
+import kabigon
+
+# Inspect the Pipeline, Targeted loaders, Execution plan, and requirements.
+plan = kabigon.explain_plan("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+loaders = kabigon.available_loaders()
+```
+
 ## Advanced loader selection
 
-Use `--loader` only when debugging, comparing loaders, or intentionally bypassing automatic pipeline planning.
+Use `--loader` only when debugging, comparing Loaders, or intentionally bypassing automatic Pipeline planning. A comma-separated loader list runs in the exact order provided.
 
 ```shell
 uvx kabigon --loader playwright https://example.com
@@ -50,12 +72,18 @@ uvx kabigon --loader youtube,youtube-ytdlp https://www.youtube.com/watch?v=dQw4w
 
 ## Supported sources
 
-- YouTube videos: transcript extraction, then optional yt-dlp + Whisper audio transcription.
-- Social posts: Twitter/X, Truth Social, Reddit, PTT, and Instagram Reels.
-- News articles: BBC and CNN article-aware extraction.
-- Code and documents: GitHub file/page content and PDF text extraction.
-- Generic web pages: Playwright browser rendering, HTTPX HTML-to-markdown, or Firecrawl.
-- Audio/video URLs: generic yt-dlp + Whisper transcription.
+- YouTube videos: `youtube`, then `youtube-ytdlp` audio transcription when needed.
+- Social posts: `twitter`, `truthsocial`, `reddit`, `ptt`, and `reel`.
+- News articles: `bbc` and `cnn` article-aware extraction.
+- Code and documents: `github` file/page content and `pdf` text extraction.
+- Generic web pages: `playwright`, `httpx`, or `firecrawl`.
+- Audio/video URLs: `ytdlp` generic audio transcription.
+
+## Failure behavior
+
+- A Loader that cannot handle the input raises a not-applicable attempt so the Load chain can continue.
+- Content extraction, timeout, and configuration failures are reported in the Load chain failure details.
+- Prefer `kabigon.explain_plan(url)` when you need to understand why a URL will use a specific Pipeline or Loader order.
 
 ## Configuration notes
 

--- a/src/kabigon/loaders/github.py
+++ b/src/kabigon/loaders/github.py
@@ -9,6 +9,7 @@ from kabigon.core.loader import Loader
 from kabigon.sources.applicability import RAW_GITHUB_HOST
 from kabigon.sources.applicability import parse_github_raw_content_target
 from kabigon.sources.applicability import parse_github_target
+from kabigon.sources.applicability import require_loader_applicability
 
 from .html_extractors import extract_first_tag_subtree
 from .utils import html_to_markdown
@@ -45,7 +46,7 @@ def extract_main_html(html: str) -> str:
 
 class GitHubLoader(Loader):
     async def load(self, url: str) -> str:
-        parse_github_target(url)
+        require_loader_applicability("GitHubLoader", url, parse_github_target)
         parsed = urlparse(url)
 
         if parsed.netloc == RAW_GITHUB_HOST or "/blob/" in parsed.path:

--- a/src/kabigon/loaders/pdf.py
+++ b/src/kabigon/loaders/pdf.py
@@ -11,6 +11,7 @@ from kabigon.core.errors import LoaderContentError
 from kabigon.core.errors import LoaderNotApplicableError
 from kabigon.core.loader import Loader
 from kabigon.sources.applicability import parse_pdf_target
+from kabigon.sources.applicability import require_loader_applicability
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ DEFAULT_HEADERS = {
 class PDFLoader(Loader):
     async def load(self, url_or_file: str) -> str:  # ty:ignore[invalid-method-override]
         logger.debug("[PDFLoader] Processing: %s", url_or_file)
-        parse_pdf_target(url_or_file)
+        require_loader_applicability("PDFLoader", url_or_file, parse_pdf_target)
 
         if not url_or_file.startswith("http"):
             # Local file

--- a/src/kabigon/loaders/youtube.py
+++ b/src/kabigon/loaders/youtube.py
@@ -4,13 +4,13 @@ import logging
 from youtube_transcript_api import YouTubeTranscriptApi
 
 from kabigon.core.errors import LoaderContentError
-from kabigon.core.errors import LoaderNotApplicableError
 from kabigon.core.loader import Loader
 from kabigon.sources.applicability import NoVideoIDFoundError
 from kabigon.sources.applicability import UnsupportedURLNetlocError
 from kabigon.sources.applicability import UnsupportedURLSchemeError
 from kabigon.sources.applicability import VideoIDError
 from kabigon.sources.applicability import parse_youtube_video_target
+from kabigon.sources.applicability import require_loader_applicability
 
 logger = logging.getLogger(__name__)
 
@@ -107,11 +107,7 @@ class YoutubeLoader(Loader):
     def load_sync(self, url: str) -> str:
         logger.debug("[YoutubeLoader] Processing URL: %s", url)
 
-        try:
-            video_id = parse_video_id(url)
-        except (UnsupportedURLSchemeError, UnsupportedURLNetlocError, NoVideoIDFoundError, VideoIDError) as e:
-            logger.debug("[YoutubeLoader] URL validation failed: %s", e)
-            raise LoaderNotApplicableError("YoutubeLoader", url, str(e)) from e
+        video_id = require_loader_applicability("YoutubeLoader", url, parse_youtube_video_target).video_id
 
         logger.debug("[YoutubeLoader] Extracted video ID: %s", video_id)
 

--- a/src/kabigon/loaders/youtube_ytdlp.py
+++ b/src/kabigon/loaders/youtube_ytdlp.py
@@ -1,14 +1,10 @@
 import asyncio
 from collections.abc import Callable
 
-from kabigon.core.errors import LoaderNotApplicableError
 from kabigon.core.loader import Loader
+from kabigon.sources.applicability import parse_youtube_video_target
+from kabigon.sources.applicability import require_loader_applicability
 
-from .youtube import NoVideoIDFoundError
-from .youtube import UnsupportedURLNetlocError
-from .youtube import UnsupportedURLSchemeError
-from .youtube import VideoIDError
-from .youtube import parse_video_id
 from .ytdlp import YtdlpLoader
 
 type LoaderFactory = Callable[[], Loader]
@@ -19,10 +15,7 @@ class YoutubeYtdlpLoader(Loader):
         self.ytdlp_loader_factory = ytdlp_loader_factory
 
     def load_sync(self, url: str) -> str:
-        try:
-            parse_video_id(url)
-        except (UnsupportedURLSchemeError, UnsupportedURLNetlocError, NoVideoIDFoundError, VideoIDError) as e:
-            raise LoaderNotApplicableError("YoutubeYtdlpLoader", url, str(e)) from e
+        require_loader_applicability("YoutubeYtdlpLoader", url, parse_youtube_video_target)
         return self.ytdlp_loader_factory().load_sync(url)
 
     async def load(self, url: str) -> str:

--- a/src/kabigon/sources/__init__.py
+++ b/src/kabigon/sources/__init__.py
@@ -43,6 +43,7 @@ from .applicability import parse_reel_target
 from .applicability import parse_truthsocial_target
 from .applicability import parse_twitter_target
 from .applicability import parse_youtube_video_target
+from .applicability import require_loader_applicability
 
 __all__ = [
     "BBC_DOMAIN_SUFFIX",
@@ -90,4 +91,5 @@ __all__ = [
     "parse_truthsocial_target",
     "parse_twitter_target",
     "parse_youtube_video_target",
+    "require_loader_applicability",
 ]

--- a/src/kabigon/sources/applicability.py
+++ b/src/kabigon/sources/applicability.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import parse_qs
@@ -76,6 +77,15 @@ class NoVideoIDFoundError(KabigonError):
         super().__init__(f"no video found in URL: {url}")
 
 
+_SOURCE_APPLICABILITY_ERRORS = (
+    InvalidURLError,
+    UnsupportedURLSchemeError,
+    UnsupportedURLNetlocError,
+    NoVideoIDFoundError,
+    VideoIDError,
+)
+
+
 @dataclass(frozen=True)
 class YouTubeVideoTarget:
     url: str
@@ -131,6 +141,19 @@ class TruthSocialTarget:
 class TwitterTarget:
     url: str
     normalized_url: str
+
+
+def require_loader_applicability[TargetT](
+    loader_name: str,
+    target: str,
+    parse_target: Callable[[str], TargetT],
+) -> TargetT:
+    try:
+        return parse_target(target)
+    except LoaderNotApplicableError:
+        raise
+    except _SOURCE_APPLICABILITY_ERRORS as e:
+        raise LoaderNotApplicableError(loader_name, target, str(e)) from e
 
 
 def parse_youtube_video_target(url: str) -> YouTubeVideoTarget:
@@ -395,4 +418,5 @@ __all__ = [
     "parse_truthsocial_target",
     "parse_twitter_target",
     "parse_youtube_video_target",
+    "require_loader_applicability",
 ]

--- a/tests/loaders/test_youtube.py
+++ b/tests/loaders/test_youtube.py
@@ -1,9 +1,11 @@
 import pytest
 
+from kabigon.core.errors import LoaderNotApplicableError
 from kabigon.loaders.youtube import NoVideoIDFoundError
 from kabigon.loaders.youtube import UnsupportedURLNetlocError
 from kabigon.loaders.youtube import UnsupportedURLSchemeError
 from kabigon.loaders.youtube import VideoIDError
+from kabigon.loaders.youtube import YoutubeLoader
 from kabigon.loaders.youtube import check_youtube_url
 from kabigon.loaders.youtube import parse_video_id
 
@@ -148,3 +150,14 @@ def test_check_youtube_url_converts_video_id_error_to_value_error() -> None:
     """Test that check_youtube_url converts VideoIDError to ValueError."""
     with pytest.raises(ValueError, match="invalid video ID"):
         check_youtube_url("https://www.youtube.com/watch?v=abc")
+
+
+def test_youtube_loader_converts_source_applicability_to_not_applicable() -> None:
+    loader = YoutubeLoader()
+
+    with pytest.raises(LoaderNotApplicableError) as exc_info:
+        loader.load_sync("https://example.com/watch?v=dQw4w9WgXcQ")
+
+    error = exc_info.value
+    assert error.loader_name == "YoutubeLoader"
+    assert error.reason == "unsupported URL netloc: example.com"

--- a/tests/loaders/test_youtube_ytdlp.py
+++ b/tests/loaders/test_youtube_ytdlp.py
@@ -16,5 +16,9 @@ class UnexpectedLoader(Loader):
 def test_youtube_ytdlp_checks_source_applicability_before_heavy_setup() -> None:
     loader = YoutubeYtdlpLoader(ytdlp_loader_factory=UnexpectedLoader)
 
-    with pytest.raises(LoaderNotApplicableError):
+    with pytest.raises(LoaderNotApplicableError) as exc_info:
         loader.load_sync("https://example.com/not-youtube")
+
+    error = exc_info.value
+    assert error.loader_name == "YoutubeYtdlpLoader"
+    assert error.reason == "unsupported URL netloc: example.com"

--- a/tests/sources/test_applicability.py
+++ b/tests/sources/test_applicability.py
@@ -1,6 +1,7 @@
 import pytest
 
 from kabigon.core.errors import InvalidURLError
+from kabigon.core.errors import LoaderNotApplicableError
 from kabigon.sources.applicability import is_bbc_url
 from kabigon.sources.applicability import is_cnn_url
 from kabigon.sources.applicability import is_github_url
@@ -15,6 +16,7 @@ from kabigon.sources.applicability import is_youtube_video_url
 from kabigon.sources.applicability import parse_github_raw_content_target
 from kabigon.sources.applicability import parse_twitter_target
 from kabigon.sources.applicability import parse_youtube_video_target
+from kabigon.sources.applicability import require_loader_applicability
 
 
 @pytest.mark.parametrize(
@@ -86,3 +88,25 @@ def test_twitter_target_normalizes_to_x_domain() -> None:
 
 def test_pdf_target_requires_pdf_suffix() -> None:
     assert not is_pdf_target("not-a-valid-url")
+
+
+def test_loader_applicability_converts_source_parse_failure() -> None:
+    with pytest.raises(LoaderNotApplicableError) as exc_info:
+        require_loader_applicability(
+            "YoutubeLoader", "https://example.com/watch?v=dQw4w9WgXcQ", parse_youtube_video_target
+        )
+
+    error = exc_info.value
+    assert error.loader_name == "YoutubeLoader"
+    assert error.url == "https://example.com/watch?v=dQw4w9WgXcQ"
+    assert error.reason == "unsupported URL netloc: example.com"
+
+
+def test_loader_applicability_preserves_loader_not_applicable_error() -> None:
+    with pytest.raises(LoaderNotApplicableError) as exc_info:
+        require_loader_applicability("TwitterLoader", "https://example.com/status/1", parse_twitter_target)
+
+    error = exc_info.value
+    assert error.loader_name == "TwitterLoader"
+    assert error.url == "https://example.com/status/1"
+    assert error.reason == "URL is not a Twitter/X URL"

--- a/tests/test_load_chain.py
+++ b/tests/test_load_chain.py
@@ -46,6 +46,15 @@ class ConstructorFailLoader(Loader):
         return "should not load"
 
 
+class SourceApplicabilityLoader(Loader):
+    async def load(self, url: str) -> str:
+        from kabigon.sources.applicability import parse_youtube_video_target
+        from kabigon.sources.applicability import require_loader_applicability
+
+        require_loader_applicability("SourceApplicabilityLoader", url, parse_youtube_video_target)
+        return "should not load"
+
+
 def test_load_chain_explains_youtube_decision() -> None:
     explanation = explain_load_chain("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
 
@@ -148,6 +157,19 @@ def test_load_chain_records_failed_attempt_details() -> None:
     assert "ContentFailLoader: Content extraction failed - parse failed" in error.details
     assert "EmptyLoader: Empty result" in error.details
     assert "Attempted loaders:" in str(error)
+
+
+def test_load_chain_records_source_applicability_as_not_applicable() -> None:
+    chain = resolve_explicit_load_chain(
+        "https://example.com/watch?v=dQw4w9WgXcQ",
+        ("source-applicability",),
+        {"source-applicability": SourceApplicabilityLoader}.__getitem__,
+    )
+
+    with pytest.raises(LoaderError) as exc_info:
+        chain.load_sync()
+
+    assert exc_info.value.details == ["SourceApplicabilityLoader: Not applicable (unsupported URL netloc: example.com)"]
 
 
 def test_explain_load_chain_does_not_build_loader_for_missing_requirement(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add a centralized Source applicability seam for converting Source parse failures into Loader not-applicable attempts
- Route YouTube, YouTube yt-dlp, GitHub, and PDF Loaders through the shared applicability helper
- Refresh the kabigon skill guidance to match automatic Pipeline planning, Python helpers, and Load chain failure behavior

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run ty check .`
- `uv run pytest -v -s --cov=src tests`