### PR TITLE
refactor: explain explicit loader requirements

### DIFF
--- a/src/kabigon/cli.py
+++ b/src/kabigon/cli.py
@@ -11,9 +11,10 @@ from kabigon.core.loader import Loader
 from kabigon.load_chain import resolve_explicit_load_chain
 from kabigon.loader_registry import get_loader_description
 from kabigon.loader_registry import get_loader_factory
+from kabigon.loader_registry import get_loader_requirements
 
 LoaderFactory = Callable[[], Loader]
-LoaderDef = tuple[str, str, LoaderFactory]
+LoaderDef = tuple[str, str, LoaderFactory, tuple[str, ...]]
 
 CLI_VISIBLE_LOADERS = (
     loader_registry.PLAYWRIGHT,
@@ -34,14 +35,19 @@ CLI_VISIBLE_LOADERS = (
 )
 
 LOADER_DEFS: list[LoaderDef] = [
-    (name, get_loader_description(name), get_loader_factory(name)) for name in CLI_VISIBLE_LOADERS
+    (name, get_loader_description(name), get_loader_factory(name), get_loader_requirements(name))
+    for name in CLI_VISIBLE_LOADERS
 ]
 
 app = typer.Typer(add_completion=False)
 
 
 def _loader_registry() -> dict[str, LoaderFactory]:
-    return {name: factory for name, _description, factory in LOADER_DEFS}
+    return {name: factory for name, _description, factory, _requirements in LOADER_DEFS}
+
+
+def _loader_requirements() -> dict[str, tuple[str, ...]]:
+    return {name: requirements for name, _description, _factory, requirements in LOADER_DEFS}
 
 
 def _exit_with_error(message: str) -> NoReturn:
@@ -62,13 +68,14 @@ def _parse_loader_names(raw: str) -> list[str]:
 
 
 def _print_loader_list() -> None:
-    for name, description, _factory in LOADER_DEFS:
+    for name, description, _factory, _requirements in LOADER_DEFS:
         typer.echo(f"{name} - {description}")
 
 
 def _load_with_loader_names(url: str, loader_names: list[str]) -> str:
     registry = _loader_registry()
-    return resolve_explicit_load_chain(url, loader_names, registry.__getitem__).load_sync()
+    requirements = _loader_requirements()
+    return resolve_explicit_load_chain(url, loader_names, registry.__getitem__, requirements.__getitem__).load_sync()
 
 
 @app.callback(invoke_without_command=True)

--- a/src/kabigon/load_chain.py
+++ b/src/kabigon/load_chain.py
@@ -15,6 +15,7 @@ from kabigon.core.errors import LoaderTimeoutError
 from kabigon.core.errors import MissingRequirementError
 from kabigon.core.loader import Loader
 from kabigon.loader_registry import get_loader_factory
+from kabigon.loader_registry import get_loader_requirements
 from kabigon.pipelines.catalog import ContentType
 from kabigon.pipelines.catalog import FallbackPolicy
 from kabigon.pipelines.catalog import match_pipeline
@@ -128,6 +129,30 @@ def _merge_unique_loaders(primary: tuple[str, ...], fallback: tuple[str, ...]) -
     return tuple(ordered)
 
 
+def _merge_unique_requirements(*requirement_groups: tuple[str, ...]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+
+    for requirement in (requirement for group in requirement_groups for requirement in group):
+        if requirement in seen:
+            continue
+        seen.add(requirement)
+        ordered.append(requirement)
+
+    return tuple(ordered)
+
+
+def _no_loader_requirements(_name: str) -> tuple[str, ...]:
+    return ()
+
+
+def _requirements_for_loaders(
+    loader_names: tuple[str, ...],
+    get_requirements: Callable[[str], tuple[str, ...]],
+) -> tuple[str, ...]:
+    return _merge_unique_requirements(*(get_requirements(name) for name in loader_names))
+
+
 def _missing_requirements(requirements: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(name for name in requirements if not os.getenv(name))
 
@@ -145,18 +170,22 @@ def explain_load_chain(url: str) -> LoadChainExplanation:
     pipeline_name: str | None = None
     content_type = ContentType.GENERIC_WEB
     targeted_loaders: tuple[str, ...] = ()
-    requirements: tuple[str, ...] = ()
+    pipeline_requirements: tuple[str, ...] = ()
     fallback = DEFAULT_FALLBACK_LOADERS
 
     if pipeline is not None:
         pipeline_name = pipeline.name
         content_type = pipeline.content_type
         targeted_loaders = pipeline.targeted_loaders
-        requirements = pipeline.requirements
+        pipeline_requirements = pipeline.requirements
         if pipeline.fallback_policy == FallbackPolicy.NO_FALLBACK:
             fallback = ()
 
     execution_plan = _merge_unique_loaders(targeted_loaders, fallback)
+    requirements = _merge_unique_requirements(
+        pipeline_requirements,
+        _requirements_for_loaders(execution_plan, get_loader_requirements),
+    )
     return LoadChainExplanation(
         url=url,
         pipeline=pipeline_name,
@@ -178,17 +207,27 @@ def resolve_explicit_load_chain(
     url: str,
     loader_names: Sequence[str],
     get_factory: Callable[[str], LoaderFactory] = get_loader_factory,
+    get_requirements: Callable[[str], tuple[str, ...]] | None = None,
 ) -> LoadChain:
     execution_plan = tuple(loader_names)
+    requirements_lookup = (
+        (get_loader_requirements if get_factory is get_loader_factory else _no_loader_requirements)
+        if get_requirements is None
+        else get_requirements
+    )
+    requirements = _requirements_for_loaders(execution_plan, requirements_lookup)
     explanation = LoadChainExplanation(
         url=url,
         pipeline=None,
         content_type=ContentType.GENERIC_WEB,
         targeted_loaders=(),
         execution_plan=execution_plan,
+        requirements=requirements,
+        missing_requirements=_missing_requirements(requirements),
     )
     if not execution_plan:
         raise ValueError(_EMPTY_EXECUTION_PLAN)
+    _ensure_requirements(explanation)
     return LoadChain(get_factory=get_factory, explanation=explanation)
 
 

--- a/src/kabigon/loader_registry.py
+++ b/src/kabigon/loader_registry.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import kabigon.loaders as loaders
 from kabigon.core.loader import Loader
 
 LoaderFactory = Callable[[], Loader]
-LoaderDef = tuple[str, str, LoaderFactory]
+
+
+@dataclass(frozen=True)
+class LoaderDef:
+    name: str
+    description: str
+    factory: LoaderFactory
+    requirements: tuple[str, ...] = ()
+
 
 PTT = "ptt"
 TWITTER = "twitter"
@@ -27,55 +36,59 @@ FIRECRAWL = "firecrawl"
 YTDLP = "ytdlp"
 
 LOADER_DEFS: tuple[LoaderDef, ...] = (
-    (PTT, "Taiwan PTT forum posts", lambda: loaders.PttLoader()),
-    (TWITTER, "Extracts Twitter/X post content", lambda: loaders.TwitterLoader()),
-    (TRUTHSOCIAL, "Extracts Truth Social posts", lambda: loaders.TruthSocialLoader()),
-    (REDDIT, "Extracts Reddit posts and comments", lambda: loaders.RedditLoader()),
-    (YOUTUBE, "Extracts YouTube video transcripts", lambda: loaders.YoutubeLoader()),
-    (REEL, "Instagram Reels audio transcription + metadata", lambda: loaders.ReelLoader()),
-    (
+    LoaderDef(PTT, "Taiwan PTT forum posts", lambda: loaders.PttLoader()),
+    LoaderDef(TWITTER, "Extracts Twitter/X post content", lambda: loaders.TwitterLoader()),
+    LoaderDef(TRUTHSOCIAL, "Extracts Truth Social posts", lambda: loaders.TruthSocialLoader()),
+    LoaderDef(REDDIT, "Extracts Reddit posts and comments", lambda: loaders.RedditLoader()),
+    LoaderDef(YOUTUBE, "Extracts YouTube video transcripts", lambda: loaders.YoutubeLoader()),
+    LoaderDef(REEL, "Instagram Reels audio transcription + metadata", lambda: loaders.ReelLoader()),
+    LoaderDef(
         YOUTUBE_YTDLP,
         "YouTube audio transcription via yt-dlp + Whisper",
         lambda: loaders.YoutubeYtdlpLoader(),
     ),
-    (PDF, "Extracts text from PDF files", lambda: loaders.PDFLoader()),
-    (GITHUB, "Fetches GitHub pages and file content", lambda: loaders.GitHubLoader()),
-    (BBC, "BBC article extraction with article-aware parsing", lambda: loaders.BBCLoader()),
-    (CNN, "CNN article extraction with article-aware parsing", lambda: loaders.CNNLoader()),
-    (
+    LoaderDef(PDF, "Extracts text from PDF files", lambda: loaders.PDFLoader()),
+    LoaderDef(GITHUB, "Fetches GitHub pages and file content", lambda: loaders.GitHubLoader()),
+    LoaderDef(BBC, "BBC article extraction with article-aware parsing", lambda: loaders.BBCLoader()),
+    LoaderDef(CNN, "CNN article extraction with article-aware parsing", lambda: loaders.CNNLoader()),
+    LoaderDef(
         PLAYWRIGHT_NETWORKIDLE,
         "Browser-based scraping with networkidle wait",
         lambda: loaders.PlaywrightLoader(timeout=50_000, wait_until="networkidle"),
     ),
-    (
+    LoaderDef(
         PLAYWRIGHT_FAST,
         "Browser-based scraping with faster defaults",
         lambda: loaders.PlaywrightLoader(timeout=10_000),
     ),
-    (PLAYWRIGHT, "Browser-based scraping for any website", lambda: loaders.PlaywrightLoader()),
-    (HTTPX, "Simple HTTP fetch + HTML to markdown", lambda: loaders.HttpxLoader()),
-    (
+    LoaderDef(PLAYWRIGHT, "Browser-based scraping for any website", lambda: loaders.PlaywrightLoader()),
+    LoaderDef(HTTPX, "Simple HTTP fetch + HTML to markdown", lambda: loaders.HttpxLoader()),
+    LoaderDef(
         FIRECRAWL,
         "Firecrawl-based web extraction (requires FIRECRAWL_API_KEY)",
         lambda: loaders.FirecrawlLoader(),
+        requirements=("FIRECRAWL_API_KEY",),
     ),
-    (YTDLP, "Audio transcription via yt-dlp + Whisper", lambda: loaders.YtdlpLoader()),
+    LoaderDef(YTDLP, "Audio transcription via yt-dlp + Whisper", lambda: loaders.YtdlpLoader()),
 )
 
-_LOADER_FACTORY_BY_NAME: dict[str, LoaderFactory] = {name: factory for name, _description, factory in LOADER_DEFS}
-_LOADER_DESCRIPTION_BY_NAME: dict[str, str] = {name: description for name, description, _factory in LOADER_DEFS}
+_LOADER_DEF_BY_NAME: dict[str, LoaderDef] = {loader_def.name: loader_def for loader_def in LOADER_DEFS}
 
 
 def get_loader_factory(name: str) -> LoaderFactory:
-    return _LOADER_FACTORY_BY_NAME[name]
+    return _LOADER_DEF_BY_NAME[name].factory
 
 
 def get_loader_description(name: str) -> str:
-    return _LOADER_DESCRIPTION_BY_NAME[name]
+    return _LOADER_DEF_BY_NAME[name].description
+
+
+def get_loader_requirements(name: str) -> tuple[str, ...]:
+    return _LOADER_DEF_BY_NAME[name].requirements
 
 
 def list_loader_names() -> list[str]:
-    return [name for name, _description, _factory in LOADER_DEFS]
+    return [loader_def.name for loader_def in LOADER_DEFS]
 
 
 __all__ = [
@@ -101,5 +114,6 @@ __all__ = [
     "LoaderFactory",
     "get_loader_description",
     "get_loader_factory",
+    "get_loader_requirements",
     "list_loader_names",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 from typer.testing import CliRunner
 
 from kabigon import cli
+from kabigon.core.errors import MissingRequirementError
 from kabigon.core.loader import Loader
 
 
@@ -25,14 +26,16 @@ class DummyLoadChain:
         return "ok"
 
 
-def make_defs(*defs: tuple[str, str, Callable[[], Loader]]) -> list[tuple[str, str, Callable[[], Loader]]]:
+def make_defs(
+    *defs: tuple[str, str, Callable[[], Loader], tuple[str, ...]],
+) -> list[tuple[str, str, Callable[[], Loader], tuple[str, ...]]]:
     return list(defs)
 
 
 def test_cli_list_outputs_loaders(monkeypatch: pytest.MonkeyPatch) -> None:
     specs = make_defs(
-        ("alpha", "Alpha loader", lambda: DummyLoader("alpha")),
-        ("beta", "Beta loader", lambda: DummyLoader("beta")),
+        ("alpha", "Alpha loader", lambda: DummyLoader("alpha"), ()),
+        ("beta", "Beta loader", lambda: DummyLoader("beta"), ()),
     )
     monkeypatch.setattr(cli, "LOADER_DEFS", specs)
 
@@ -46,15 +49,21 @@ def test_cli_list_outputs_loaders(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_cli_loader_selection_uses_load_chain_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     specs = make_defs(
-        ("first", "First loader", lambda: DummyLoader("first")),
-        ("second", "Second loader", lambda: DummyLoader("second")),
+        ("first", "First loader", lambda: DummyLoader("first"), ()),
+        ("second", "Second loader", lambda: DummyLoader("second"), ()),
     )
     monkeypatch.setattr(cli, "LOADER_DEFS", specs)
 
-    def fake_resolve(url: str, loader_names: list[str], get_factory: Callable[[str], Callable[[], Loader]]):
+    def fake_resolve(
+        url: str,
+        loader_names: list[str],
+        get_factory: Callable[[str], Callable[[], Loader]],
+        get_requirements: Callable[[str], tuple[str, ...]],
+    ):
         assert url == "https://example.com"
         assert loader_names == ["first", "second"]
         assert isinstance(get_factory("first")(), DummyLoader)
+        assert get_requirements("first") == ()
         return DummyLoadChain()
 
     monkeypatch.setattr(cli, "resolve_explicit_load_chain", fake_resolve)
@@ -78,3 +87,14 @@ def test_cli_default_pipeline_uses_load_url_sync(monkeypatch: pytest.MonkeyPatch
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "content"
+
+
+def test_cli_loader_selection_reports_missing_requirements(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["--loader", "firecrawl", "https://example.com"])
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, MissingRequirementError)
+    assert "FIRECRAWL_API_KEY" in str(result.exception)

--- a/tests/test_load_chain.py
+++ b/tests/test_load_chain.py
@@ -109,6 +109,48 @@ def test_explicit_load_chain_uses_shared_attempt_runtime() -> None:
     assert chain.load_sync() == "loaded https://example.com"
 
 
+def test_explicit_load_chain_explains_loader_requirements(monkeypatch) -> None:
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "test-key")
+
+    chain = resolve_explicit_load_chain("https://example.com", ("firecrawl",))
+
+    assert chain.explanation.pipeline is None
+    assert chain.explanation.execution_plan == ("firecrawl",)
+    assert chain.explanation.requirements == ("FIRECRAWL_API_KEY",)
+    assert chain.explanation.missing_requirements == ()
+
+
+def test_explicit_load_chain_checks_requirements_before_building_loader(monkeypatch) -> None:
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+
+    with pytest.raises(MissingRequirementError, match="FIRECRAWL_API_KEY"):
+        resolve_explicit_load_chain("https://example.com", ("firecrawl",))
+
+
+def test_explicit_load_chain_keeps_custom_registry_requirements_opt_in() -> None:
+    chain = resolve_explicit_load_chain(
+        "https://example.com",
+        ("success",),
+        {"success": SuccessLoader}.__getitem__,
+    )
+
+    assert chain.explanation.requirements == ()
+
+
+def test_explicit_load_chain_accepts_injected_loader_requirements(monkeypatch) -> None:
+    monkeypatch.setenv("CUSTOM_REQUIREMENT", "yes")
+
+    chain = resolve_explicit_load_chain(
+        "https://example.com",
+        ("success",),
+        {"success": SuccessLoader}.__getitem__,
+        lambda name: ("CUSTOM_REQUIREMENT",) if name == "success" else (),
+    )
+
+    assert chain.explanation.requirements == ("CUSTOM_REQUIREMENT",)
+    assert chain.load_sync() == "loaded https://example.com"
+
+
 def test_load_chain_builds_loaders_only_when_attempted() -> None:
     built: list[str] = []
 

--- a/tests/test_registry_planning_consistency.py
+++ b/tests/test_registry_planning_consistency.py
@@ -1,4 +1,6 @@
 from kabigon.load_chain import DEFAULT_FALLBACK_LOADERS
+from kabigon.loader_registry import FIRECRAWL
+from kabigon.loader_registry import get_loader_requirements
 from kabigon.loader_registry import list_loader_names
 from kabigon.pipelines.catalog import list_pipelines
 
@@ -17,3 +19,10 @@ def test_pipeline_targeted_loaders_registered() -> None:
         missing.extend(name for name in pipeline.targeted_loaders if name not in registered)
 
     assert missing == []
+
+
+def test_firecrawl_loader_requirements_match_pipeline_metadata() -> None:
+    firecrawl_pipelines = [pipeline for pipeline in list_pipelines() if FIRECRAWL in pipeline.targeted_loaders]
+
+    assert firecrawl_pipelines
+    assert all(pipeline.requirements == get_loader_requirements(FIRECRAWL) for pipeline in firecrawl_pipelines)


### PR DESCRIPTION
## Summary
- Add Loader requirements metadata to the Loader registry, starting with `firecrawl` and `FIRECRAWL_API_KEY`
- Include Loader requirements in automatic and explicit Load chain explanations before Loader construction
- Keep CLI explicit loader composition local while passing requirement metadata into the Load chain

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run ty check .`
- `uv run pytest -v -s --cov=src tests`