### PR TITLE
[codex] deepen load chain planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Interface (CLI)  →  Application (pipeline catalog, load chain)  →  Domain (L
 3. `load_chain.py` turns that into a runnable load chain: targeted loaders followed by fallback loaders, plus explanation metadata.
 4. `load_chain.py` executes the ordered Loader attempts and returns the first successful result.
 
-`explain_plan()` returns Pipeline, requirement, and execution-plan metadata without constructing concrete loaders. Actual loading builds and executes the runnable Load chain.
+`explain_plan()` returns Pipeline, Targeted loader, Fallback loader, requirement, and Execution plan metadata without constructing concrete loaders. Actual loading builds and executes the runnable Load chain.
 
 There are three fallback levels to keep distinct:
 

--- a/src/kabigon/load_chain.py
+++ b/src/kabigon/load_chain.py
@@ -48,6 +48,7 @@ class LoadChainExplanation:
     pipeline: str | None
     content_type: ContentType
     targeted_loaders: tuple[str, ...]
+    fallback_loaders: tuple[str, ...]
     execution_plan: tuple[str, ...]
     requirements: tuple[str, ...] = ()
     missing_requirements: tuple[str, ...] = ()
@@ -58,10 +59,18 @@ class LoadChainExplanation:
             "pipeline": self.pipeline,
             "content_type": self.content_type,
             "targeted_loaders": list(self.targeted_loaders),
+            "fallback_loaders": list(self.fallback_loaders),
             "execution_plan": list(self.execution_plan),
             "requirements": list(self.requirements),
             "missing_requirements": list(self.missing_requirements),
         }
+
+
+@dataclass(frozen=True)
+class _ExecutionPlan:
+    targeted_loaders: tuple[str, ...]
+    fallback_loaders: tuple[str, ...]
+    loaders: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -116,11 +125,11 @@ class LoadChain:
         return asyncio.run(self.load())
 
 
-def _merge_unique_loaders(primary: tuple[str, ...], fallback: tuple[str, ...]) -> tuple[str, ...]:
-    seen: set[str] = set()
+def _remaining_unique_loaders(primary: tuple[str, ...], fallback: tuple[str, ...]) -> tuple[str, ...]:
+    seen = set(primary)
     ordered: list[str] = []
 
-    for loader_name in (*primary, *fallback):
+    for loader_name in fallback:
         if loader_name in seen:
             continue
         seen.add(loader_name)
@@ -157,6 +166,23 @@ def _missing_requirements(requirements: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(name for name in requirements if not os.getenv(name))
 
 
+def _build_execution_plan(
+    targeted_loaders: tuple[str, ...],
+    fallback_policy: FallbackPolicy,
+) -> _ExecutionPlan:
+    fallback_candidates: tuple[str, ...] = ()
+    if fallback_policy == FallbackPolicy.REMAINING_DEFAULT:
+        fallback_candidates = DEFAULT_FALLBACK_LOADERS
+
+    fallback_loaders = _remaining_unique_loaders(targeted_loaders, fallback_candidates)
+
+    return _ExecutionPlan(
+        targeted_loaders=targeted_loaders,
+        fallback_loaders=fallback_loaders,
+        loaders=(*targeted_loaders, *fallback_loaders),
+    )
+
+
 def _ensure_requirements(explanation: LoadChainExplanation) -> None:
     if not explanation.missing_requirements:
         return
@@ -170,28 +196,23 @@ def explain_load_chain(url: str) -> LoadChainExplanation:
     pipeline_name: str | None = None
     content_type = ContentType.GENERIC_WEB
     targeted_loaders: tuple[str, ...] = ()
-    pipeline_requirements: tuple[str, ...] = ()
-    fallback = DEFAULT_FALLBACK_LOADERS
+    fallback_policy = FallbackPolicy.REMAINING_DEFAULT
 
     if pipeline is not None:
         pipeline_name = pipeline.name
         content_type = pipeline.content_type
         targeted_loaders = pipeline.targeted_loaders
-        pipeline_requirements = pipeline.requirements
-        if pipeline.fallback_policy == FallbackPolicy.NO_FALLBACK:
-            fallback = ()
+        fallback_policy = pipeline.fallback_policy
 
-    execution_plan = _merge_unique_loaders(targeted_loaders, fallback)
-    requirements = _merge_unique_requirements(
-        pipeline_requirements,
-        _requirements_for_loaders(execution_plan, get_loader_requirements),
-    )
+    execution_plan = _build_execution_plan(targeted_loaders, fallback_policy)
+    requirements = _requirements_for_loaders(execution_plan.loaders, get_loader_requirements)
     return LoadChainExplanation(
         url=url,
         pipeline=pipeline_name,
         content_type=content_type,
-        targeted_loaders=targeted_loaders,
-        execution_plan=execution_plan,
+        targeted_loaders=execution_plan.targeted_loaders,
+        fallback_loaders=execution_plan.fallback_loaders,
+        execution_plan=execution_plan.loaders,
         requirements=requirements,
         missing_requirements=_missing_requirements(requirements),
     )
@@ -221,6 +242,7 @@ def resolve_explicit_load_chain(
         pipeline=None,
         content_type=ContentType.GENERIC_WEB,
         targeted_loaders=(),
+        fallback_loaders=(),
         execution_plan=execution_plan,
         requirements=requirements,
         missing_requirements=_missing_requirements(requirements),

--- a/src/kabigon/pipelines/catalog.py
+++ b/src/kabigon/pipelines/catalog.py
@@ -39,7 +39,6 @@ class Pipeline:
     name: str
     content_type: ContentType
     targeted_loaders: tuple[str, ...]
-    requirements: tuple[str, ...] = ()
     fallback_policy: FallbackPolicy = FallbackPolicy.REMAINING_DEFAULT
 
 
@@ -127,7 +126,6 @@ _PIPELINE_ENTRIES: tuple[_PipelineEntry, ...] = (
             name="openai_web",
             content_type=ContentType.GENERIC_WEB,
             targeted_loaders=(loader_names.FIRECRAWL,),
-            requirements=("FIRECRAWL_API_KEY",),
             fallback_policy=FallbackPolicy.NO_FALLBACK,
         ),
         matches=is_openai_web_url,

--- a/tests/pipelines/test_catalog.py
+++ b/tests/pipelines/test_catalog.py
@@ -123,7 +123,6 @@ def test_match_pipeline_openai_web(url: str) -> None:
     assert pipeline.name == "openai_web"
     assert pipeline.content_type == ContentType.GENERIC_WEB
     assert pipeline.targeted_loaders == ("firecrawl",)
-    assert pipeline.requirements == ("FIRECRAWL_API_KEY",)
     assert pipeline.fallback_policy == FallbackPolicy.NO_FALLBACK
 
 

--- a/tests/test_load_chain.py
+++ b/tests/test_load_chain.py
@@ -61,6 +61,9 @@ def test_load_chain_explains_youtube_decision() -> None:
     assert explanation.pipeline == "youtube"
     assert explanation.content_type == ContentType.YOUTUBE_VIDEO
     assert explanation.targeted_loaders == ("youtube", "youtube-ytdlp")
+    assert explanation.fallback_loaders == tuple(
+        loader_name for loader_name in DEFAULT_FALLBACK_LOADERS if loader_name not in explanation.targeted_loaders
+    )
     assert explanation.execution_plan[:2] == ("youtube", "youtube-ytdlp")
     assert explanation.requirements == ()
 
@@ -71,6 +74,7 @@ def test_load_chain_explains_generic_web_default_order() -> None:
     assert explanation.pipeline is None
     assert explanation.content_type == ContentType.GENERIC_WEB
     assert explanation.targeted_loaders == ()
+    assert explanation.fallback_loaders == DEFAULT_FALLBACK_LOADERS
     assert explanation.execution_plan == DEFAULT_FALLBACK_LOADERS
 
 
@@ -87,6 +91,8 @@ def test_load_chain_for_no_fallback_pipeline_builds_single_loader(monkeypatch) -
     chain = resolve_load_chain("https://openai.com/pricing")
 
     assert chain.explanation.pipeline == "openai_web"
+    assert chain.explanation.targeted_loaders == ("firecrawl",)
+    assert chain.explanation.fallback_loaders == ()
     assert chain.explanation.execution_plan == ("firecrawl",)
     assert chain.explanation.requirements == ("FIRECRAWL_API_KEY",)
     assert chain.explanation.missing_requirements == ()
@@ -115,6 +121,7 @@ def test_explicit_load_chain_explains_loader_requirements(monkeypatch) -> None:
     chain = resolve_explicit_load_chain("https://example.com", ("firecrawl",))
 
     assert chain.explanation.pipeline is None
+    assert chain.explanation.fallback_loaders == ()
     assert chain.explanation.execution_plan == ("firecrawl",)
     assert chain.explanation.requirements == ("FIRECRAWL_API_KEY",)
     assert chain.explanation.missing_requirements == ()
@@ -220,6 +227,8 @@ def test_explain_load_chain_does_not_build_loader_for_missing_requirement(monkey
     explanation = explain_load_chain("https://openai.com/pricing")
 
     assert explanation.pipeline == "openai_web"
+    assert explanation.targeted_loaders == ("firecrawl",)
+    assert explanation.fallback_loaders == ()
     assert explanation.execution_plan == ("firecrawl",)
     assert explanation.requirements == ("FIRECRAWL_API_KEY",)
     assert explanation.missing_requirements == ("FIRECRAWL_API_KEY",)
@@ -240,6 +249,7 @@ def test_load_chain_explanation_as_dict_uses_public_shapes() -> None:
         "pipeline": "youtube",
         "content_type": ContentType.YOUTUBE_VIDEO,
         "targeted_loaders": ["youtube", "youtube-ytdlp"],
+        "fallback_loaders": list(explanation.fallback_loaders),
         "execution_plan": list(explanation.execution_plan),
         "requirements": [],
         "missing_requirements": [],

--- a/tests/test_registry_planning_consistency.py
+++ b/tests/test_registry_planning_consistency.py
@@ -1,6 +1,4 @@
 from kabigon.load_chain import DEFAULT_FALLBACK_LOADERS
-from kabigon.loader_registry import FIRECRAWL
-from kabigon.loader_registry import get_loader_requirements
 from kabigon.loader_registry import list_loader_names
 from kabigon.pipelines.catalog import list_pipelines
 
@@ -19,10 +17,3 @@ def test_pipeline_targeted_loaders_registered() -> None:
         missing.extend(name for name in pipeline.targeted_loaders if name not in registered)
 
     assert missing == []
-
-
-def test_firecrawl_loader_requirements_match_pipeline_metadata() -> None:
-    firecrawl_pipelines = [pipeline for pipeline in list_pipelines() if FIRECRAWL in pipeline.targeted_loaders]
-
-    assert firecrawl_pipelines
-    assert all(pipeline.requirements == get_loader_requirements(FIRECRAWL) for pipeline in firecrawl_pipelines)


### PR DESCRIPTION
## Summary

- centralize Execution plan construction in the Load chain and expose separate targeted and fallback loader metadata
- derive Load chain requirements from the planned Loader list instead of duplicating Loader requirements in Pipeline metadata
- update README and tests around the public planning shape

## Impact

`explain_plan()` now includes `fallback_loaders` in addition to the full `execution_plan`. Firecrawl requirements remain visible through Load chain planning, but the Pipeline catalog no longer owns duplicated requirement metadata.

## Validation

- `uv run pytest -q tests/test_load_chain.py tests/pipelines/test_catalog.py tests/test_registry_planning_consistency.py tests/test_load_url.py`
- `uv run ruff check .`
- `uv run ty check .`
- `uv run pytest -q`
- `uv run ruff format --check .`