### PR TITLE
fix: support arxiv PDF endpoints

### DIFF
--- a/src/kabigon/sources/applicability.py
+++ b/src/kabigon/sources/applicability.py
@@ -27,6 +27,10 @@ YOUTUBE_ALLOWED_NETLOCS = {
     "vid.plus",
 }
 GITHUB_HOST = "github.com"
+ARXIV_HOSTS = (
+    "arxiv.org",
+    "www.arxiv.org",
+)
 OPENAI_WEB_HOSTS = (
     "openai.com",
     "www.openai.com",
@@ -228,7 +232,8 @@ def is_github_url(url: str) -> bool:
 def parse_pdf_target(target: str) -> PDFTarget:
     parsed = urlparse(target)
     if parsed.scheme in {"http", "https"}:
-        if not parsed.path.lower().endswith(".pdf"):
+        path = parsed.path.lower()
+        if not path.endswith(".pdf") and not (parsed.netloc.lower() in ARXIV_HOSTS and path.startswith("/pdf/")):
             raise InvalidURLError(target, "PDF")
         return PDFTarget(target=target)
 

--- a/tests/pipelines/test_catalog.py
+++ b/tests/pipelines/test_catalog.py
@@ -75,6 +75,15 @@ def test_match_pipeline_non_http_pdf_path() -> None:
     assert pipeline.targeted_loaders == ("pdf",)
 
 
+def test_match_pipeline_arxiv_pdf_endpoint() -> None:
+    pipeline = match_pipeline("https://arxiv.org/pdf/2603.20617")
+
+    assert pipeline is not None
+    assert pipeline.name == "pdf"
+    assert pipeline.content_type == ContentType.DOCUMENT_PDF
+    assert pipeline.targeted_loaders == ("pdf",)
+
+
 def test_match_pipeline_non_http_non_pdf_path_returns_none() -> None:
     assert match_pipeline("not-a-valid-url") is None
 

--- a/tests/sources/test_applicability.py
+++ b/tests/sources/test_applicability.py
@@ -33,6 +33,7 @@ from kabigon.sources.applicability import require_loader_applicability
         ("https://edition.cnn.com/2026/03/16/tech/example", is_cnn_url),
         ("https://openai.com/pricing", is_openai_web_url),
         ("/tmp/demo.pdf", is_pdf_target),
+        ("https://arxiv.org/pdf/2603.20617", is_pdf_target),
     ],
 )
 def test_source_applicability_accepts_supported_targets(url, is_applicable) -> None:


### PR DESCRIPTION
## Summary
- Treat arXiv `/pdf/<id>` URLs as PDF targets even when they do not end in `.pdf`.
- Keep PDF content validation in `PDFLoader` via the response content type.
- Add source applicability and pipeline routing coverage for arXiv PDF URLs.

## Verification
- `uv run pytest -v -s tests/sources/test_applicability.py tests/pipelines/test_catalog.py`
- `uv run ruff check src/kabigon/sources/applicability.py tests/sources/test_applicability.py tests/pipelines/test_catalog.py`
- `uv run ty check .`
- `uv run kabigon https://arxiv.org/pdf/2603.20617`