### PR TITLE
feat: add loader info logging

### DIFF
--- a/src/kabigon/cli.py
+++ b/src/kabigon/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import NoReturn
 
@@ -40,6 +41,7 @@ LOADER_DEFS: list[LoaderDef] = [
 ]
 
 app = typer.Typer(add_completion=False)
+LOG_FORMAT = "%(asctime)s | %(levelname)s | %(name)s:%(lineno)d - %(message)s"
 
 
 def _loader_registry() -> dict[str, LoaderFactory]:
@@ -72,6 +74,11 @@ def _print_loader_list() -> None:
         typer.echo(f"{name} - {description}")
 
 
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(format=LOG_FORMAT, level=level)
+
+
 def _load_with_loader_names(url: str, loader_names: list[str]) -> str:
     registry = _loader_registry()
     requirements = _loader_requirements()
@@ -83,7 +90,10 @@ def _main(
     url: str | None = typer.Argument(None, metavar="URL"),
     loader: str | None = typer.Option(None, "--loader", help="Comma-separated loader names"),
     list_: bool = typer.Option(False, "--list", help="List supported loaders"),
+    verbose: bool = typer.Option(False, "--verbose", help="Show debug logging"),
 ) -> None:
+    _configure_logging(verbose)
+
     if list_:
         if url is not None or loader is not None:
             _exit_with_error("--list cannot be combined with URL or --loader.")

--- a/src/kabigon/loaders/browser.py
+++ b/src/kabigon/loaders/browser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable
 from collections.abc import Callable
 from typing import Literal
@@ -21,6 +22,8 @@ DEFAULT_BROWSER_USER_AGENT = (
 )
 DEFAULT_BLOCKED_RESOURCE_TYPES = frozenset({"font", "image", "media"})
 
+logger = logging.getLogger(__name__)
+
 
 async def fetch_browser_html(
     url: str,
@@ -36,16 +39,20 @@ async def fetch_browser_html(
     extract_content: BrowserContentExtractor | None = None,
 ) -> str:
     async with async_playwright() as p:
+        logger.debug("[%s] Launching Chromium browser (headless=%s)", loader_name, browser_headless)
         browser = await p.chromium.launch(headless=browser_headless)
         context = None
         try:
             if user_agent is None:
+                logger.debug("[%s] Creating browser context", loader_name)
                 context = await browser.new_context()
             else:
+                logger.debug("[%s] Creating browser context with custom user agent", loader_name)
                 context = await browser.new_context(user_agent=user_agent)
             page = await context.new_page()
 
             if block_resource_types:
+                logger.debug("[%s] Blocking browser resource types: %s", loader_name, sorted(block_resource_types))
 
                 async def route_handler(route: Route, request: Request) -> None:
                     if request.resource_type in block_resource_types:
@@ -56,23 +63,35 @@ async def fetch_browser_html(
                 await page.route("**/*", route_handler)
 
             try:
+                logger.debug(
+                    "[%s] Navigating to URL (timeout_ms=%s, wait_until=%s)",
+                    loader_name,
+                    timeout_ms,
+                    wait_until,
+                )
                 if wait_until is None:
                     await page.goto(url, timeout=timeout_ms)
                 else:
                     await page.goto(url, timeout=timeout_ms, wait_until=wait_until)
             except TimeoutError as e:
                 timeout_seconds = (timeout_ms or 0) / 1000 if timeout_ms else 30
+                logger.warning("[%s] Browser navigation timed out after %ss", loader_name, timeout_seconds)
                 raise LoaderTimeoutError(loader_name, url, timeout_seconds, timeout_suggestion) from e
 
             if after_goto is not None:
+                logger.debug("[%s] Running post-navigation hook", loader_name)
                 await after_goto(page)
 
             if extract_content is not None:
+                logger.debug("[%s] Extracting browser content with custom extractor", loader_name)
                 return await extract_content(page)
+            logger.debug("[%s] Extracting full browser page content", loader_name)
             return await page.content()
         finally:
             if context is not None:
+                logger.debug("[%s] Closing browser context", loader_name)
                 await context.close()
+            logger.debug("[%s] Closing Chromium browser", loader_name)
             await browser.close()
 
 

--- a/src/kabigon/loaders/firecrawl.py
+++ b/src/kabigon/loaders/firecrawl.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 from typing import Any
 
@@ -7,6 +8,8 @@ from firecrawl import FirecrawlApp
 from kabigon.core.errors import FirecrawlAPIKeyNotSetError
 from kabigon.core.errors import LoaderError
 from kabigon.core.loader import Loader
+
+logger = logging.getLogger(__name__)
 
 
 class FirecrawlLoader(Loader):
@@ -17,22 +20,27 @@ class FirecrawlLoader(Loader):
         if not api_key:
             raise FirecrawlAPIKeyNotSetError
 
+        logger.debug("[FirecrawlLoader] Found FIRECRAWL_API_KEY")
         self.app: Any = FirecrawlApp(api_key=api_key)
 
     def load_sync(self, url: str) -> str:
+        logger.info("[FirecrawlLoader] Processing URL: %s", url)
         scrape_kwargs = {
             "formats": ["markdown"],
             "timeout": self.timeout,
         }
         if hasattr(self.app, "scrape_url"):
+            logger.info("[FirecrawlLoader] Fetching URL with scrape_url (timeout=%s)", self.timeout)
             result = self.app.scrape_url(url, **scrape_kwargs)
         elif hasattr(self.app, "scrape"):
+            logger.info("[FirecrawlLoader] Fetching URL with scrape (timeout=%s)", self.timeout)
             result = self.app.scrape(url, **scrape_kwargs)
         else:
             raise LoaderError(url, ["Firecrawl SDK does not expose scrape methods"])
 
         success = getattr(result, "success", None)
         if success is False:
+            logger.warning("[FirecrawlLoader] Firecrawl scrape returned unsuccessful result")
             raise LoaderError(url, ["Firecrawl scrape returned unsuccessful result"])
 
         markdown = getattr(result, "markdown", None)
@@ -40,6 +48,7 @@ class FirecrawlLoader(Loader):
             markdown = result.get("markdown")
         if not isinstance(markdown, str):
             raise LoaderError(url, ["Firecrawl scrape result did not include markdown"])
+        logger.info("[FirecrawlLoader] Extracted markdown content (%s chars)", len(markdown))
         return markdown
 
     async def load(self, url: str) -> str:

--- a/src/kabigon/loaders/github.py
+++ b/src/kabigon/loaders/github.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from urllib.parse import urlparse
 
 import httpx
@@ -13,6 +14,8 @@ from kabigon.sources.applicability import require_loader_applicability
 
 from .html_extractors import extract_first_tag_subtree
 from .utils import html_to_markdown
+
+logger = logging.getLogger(__name__)
 
 _IGNORED_TAGS = {
     "script",
@@ -46,11 +49,13 @@ def extract_main_html(html: str) -> str:
 
 class GitHubLoader(Loader):
     async def load(self, url: str) -> str:
+        logger.info("[GitHubLoader] Processing URL: %s", url)
         require_loader_applicability("GitHubLoader", url, parse_github_target)
         parsed = urlparse(url)
 
         if parsed.netloc == RAW_GITHUB_HOST or "/blob/" in parsed.path:
             raw_url = to_raw_github_url(url)
+            logger.info("[GitHubLoader] Fetching raw GitHub content: %s", raw_url)
 
             async with httpx.AsyncClient() as client:
                 response = await client.get(
@@ -61,11 +66,14 @@ class GitHubLoader(Loader):
                 response.raise_for_status()
 
             content_type = response.headers.get("content-type", "")
+            logger.debug("[GitHubLoader] Raw content-type: %s", content_type)
             if "text" not in content_type and "json" not in content_type and "xml" not in content_type:
                 raise InvalidURLError(url, f"GitHub text content-type (got {content_type!r})")
 
+            logger.info("[GitHubLoader] Loaded raw GitHub content (%s chars)", len(response.text))
             return response.text
 
+        logger.info("[GitHubLoader] Fetching GitHub HTML page")
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 url,
@@ -78,8 +86,11 @@ class GitHubLoader(Loader):
             response.raise_for_status()
 
         content_type = response.headers.get("content-type", "")
+        logger.debug("[GitHubLoader] HTML content-type: %s", content_type)
         if "html" not in content_type:
             raise InvalidURLError(url, f"GitHub HTML content-type (got {content_type!r})")
 
         main_html = extract_main_html(response.text)
-        return html_to_markdown(main_html)
+        result = html_to_markdown(main_html)
+        logger.info("[GitHubLoader] Extracted GitHub HTML content (%s chars)", len(result))
+        return result

--- a/src/kabigon/loaders/httpx.py
+++ b/src/kabigon/loaders/httpx.py
@@ -15,9 +15,10 @@ class HttpxLoader(Loader):
         self.headers = headers
 
     async def load(self, url: str) -> str:
-        logger.debug("[HttpxLoader] Fetching URL: %s", url)
+        logger.info("[HttpxLoader] Processing URL: %s", url)
 
         try:
+            logger.info("[HttpxLoader] Fetching HTML content")
             async with httpx.AsyncClient() as client:
                 response = await client.get(url, headers=self.headers, follow_redirects=True)
                 response.raise_for_status()
@@ -28,5 +29,5 @@ class HttpxLoader(Loader):
             ) from e
 
         result = html_to_markdown(response.content)
-        logger.debug("[HttpxLoader] Successfully converted to markdown (%s chars)", len(result))
+        logger.info("[HttpxLoader] Extracted HTML content (%s chars)", len(result))
         return result

--- a/src/kabigon/loaders/news_article.py
+++ b/src/kabigon/loaders/news_article.py
@@ -40,9 +40,10 @@ async def load_news_article(
     headers: dict[str, str],
 ) -> str:
     validate_url(url)
-    logger.debug("[%s] Fetching URL: %s", loader_name, url)
+    logger.info("[%s] Processing URL: %s", loader_name, url)
 
     try:
+        logger.info("[%s] Fetching article HTML", loader_name)
         async with httpx.AsyncClient() as client:
             response = await client.get(url, headers=headers, follow_redirects=True)
             response.raise_for_status()
@@ -56,10 +57,10 @@ async def load_news_article(
 
     json_ld_body = extract_article_body_from_json_ld(response.text)
     if json_ld_body:
-        logger.debug("[%s] Extracted articleBody from JSON-LD (%s chars)", loader_name, len(json_ld_body))
+        logger.info("[%s] Extracted articleBody from JSON-LD (%s chars)", loader_name, len(json_ld_body))
         return json_ld_body
 
     main_html = extract_news_article_main_html(response.text)
     result = html_to_markdown(main_html)
-    logger.debug("[%s] Extracted article HTML content (%s chars)", loader_name, len(result))
+    logger.info("[%s] Extracted article HTML content (%s chars)", loader_name, len(result))
     return result

--- a/src/kabigon/loaders/pdf.py
+++ b/src/kabigon/loaders/pdf.py
@@ -23,12 +23,13 @@ DEFAULT_HEADERS = {
 
 class PDFLoader(Loader):
     async def load(self, url_or_file: str) -> str:  # ty:ignore[invalid-method-override]
-        logger.debug("[PDFLoader] Processing: %s", url_or_file)
+        logger.info("[PDFLoader] Processing URL or file: %s", url_or_file)
         require_loader_applicability("PDFLoader", url_or_file, parse_pdf_target)
 
         if not url_or_file.startswith("http"):
             # Local file
-            logger.debug("[PDFLoader] Reading local file: %s", url_or_file)
+            logger.info("[PDFLoader] Reading local PDF file")
+            logger.debug("[PDFLoader] Local PDF path: %s", url_or_file)
             try:
                 result = read_pdf_content(url_or_file)
             except Exception as e:
@@ -40,10 +41,11 @@ class PDFLoader(Loader):
                     "Check that the file exists and is a valid PDF.",
                 ) from e
             else:
-                logger.debug("[PDFLoader] Successfully read local PDF (%s chars)", len(result))
+                logger.info("[PDFLoader] Loaded local PDF content (%s chars)", len(result))
                 return result
 
         # Remote URL
+        logger.info("[PDFLoader] Fetching remote PDF")
         async with httpx.AsyncClient() as client:
             try:
                 resp = await client.get(url_or_file, headers=DEFAULT_HEADERS, follow_redirects=True)
@@ -72,7 +74,7 @@ class PDFLoader(Loader):
                     "The PDF may be corrupted or use unsupported features.",
                 ) from e
             else:
-                logger.debug("[PDFLoader] Successfully read remote PDF (%s chars)", len(result))
+                logger.info("[PDFLoader] Loaded remote PDF content (%s chars)", len(result))
                 return result
 
 

--- a/src/kabigon/loaders/playwright.py
+++ b/src/kabigon/loaders/playwright.py
@@ -21,7 +21,8 @@ class PlaywrightLoader(Loader):
         self.browser_headless = browser_headless
 
     async def load(self, url: str) -> str:
-        logger.debug(
+        logger.info("[PlaywrightLoader] Processing URL: %s", url)
+        logger.info(
             "[PlaywrightLoader] Loading URL: %s (timeout=%s, wait_until=%s)",
             url,
             self.timeout,
@@ -38,7 +39,7 @@ class PlaywrightLoader(Loader):
             wait_until=self.wait_until,
             browser_headless=self.browser_headless,
         )
-        logger.debug("[PlaywrightLoader] Successfully loaded page")
+        logger.debug("[PlaywrightLoader] Loaded browser page")
         result = html_to_markdown(content)
-        logger.debug("[PlaywrightLoader] Successfully extracted content (%s chars)", len(result))
+        logger.info("[PlaywrightLoader] Extracted browser page content (%s chars)", len(result))
         return result

--- a/src/kabigon/loaders/ptt.py
+++ b/src/kabigon/loaders/ptt.py
@@ -23,9 +23,10 @@ class PttLoader(Loader):
         )
 
     async def load(self, url: str) -> str:
-        logger.debug("[PttLoader] Processing URL: %s", url)
+        logger.info("[PttLoader] Processing URL: %s", url)
         parse_ptt_target(url)
 
+        logger.info("[PttLoader] Fetching PTT HTML content")
         result = await self.httpx_loader.load(url)
-        logger.debug("[PttLoader] Successfully loaded content (%s chars)", len(result))
+        logger.info("[PttLoader] Extracted PTT content (%s chars)", len(result))
         return result

--- a/src/kabigon/loaders/reddit.py
+++ b/src/kabigon/loaders/reddit.py
@@ -213,6 +213,8 @@ class RedditLoader(Loader):
         }
 
         try:
+            logger.info("[RedditLoader] Fetching Reddit JSON endpoint")
+            logger.debug("[RedditLoader] Reddit JSON URL: %s", api_url)
             async with httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=True) as client:
                 response = await client.get(api_url, headers=headers)
                 response.raise_for_status()
@@ -246,6 +248,8 @@ class RedditLoader(Loader):
         rss_url = to_reddit_rss_url(url)
         timeout_seconds = self.timeout / 1000
         try:
+            logger.info("[RedditLoader] Fetching Reddit RSS fallback")
+            logger.debug("[RedditLoader] Reddit RSS URL: %s", rss_url)
             async with httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=True) as client:
                 response = await client.get(rss_url)
                 response.raise_for_status()
@@ -268,7 +272,8 @@ class RedditLoader(Loader):
 
     async def _load_via_old_reddit(self, url: str) -> str:
         old_reddit_url = convert_to_old_reddit(url)
-        logger.debug("[RedditLoader] Converted to old Reddit: %s", old_reddit_url)
+        logger.info("[RedditLoader] Fetching old Reddit browser fallback")
+        logger.debug("[RedditLoader] Old Reddit URL: %s", old_reddit_url)
 
         content = await fetch_browser_html(
             old_reddit_url,
@@ -278,7 +283,7 @@ class RedditLoader(Loader):
             wait_until="networkidle",
             user_agent=DEFAULT_BROWSER_USER_AGENT,
         )
-        logger.debug("[RedditLoader] Page loaded successfully via old Reddit")
+        logger.debug("[RedditLoader] Loaded old Reddit browser page")
         return html_to_markdown(content)
 
     async def load(self, url: str) -> str:
@@ -294,7 +299,7 @@ class RedditLoader(Loader):
             LoaderNotApplicableError: If URL is not from Reddit
             LoaderTimeoutError: If page loading times out
         """
-        logger.debug("[RedditLoader] Processing URL: %s", url)
+        logger.info("[RedditLoader] Processing URL: %s", url)
         parse_reddit_target(url)
         try:
             result = await self._load_via_json(url)
@@ -305,13 +310,13 @@ class RedditLoader(Loader):
             except (LoaderContentError, LoaderTimeoutError) as rss_error:
                 logger.warning("[RedditLoader] RSS fallback failed, falling back to old Reddit: %s", rss_error)
                 result = await self._load_via_old_reddit(url)
-                logger.debug(
-                    "[RedditLoader] Successfully extracted content from old Reddit fallback (%s chars)",
+                logger.info(
+                    "[RedditLoader] Extracted content from old Reddit fallback (%s chars)",
                     len(result),
                 )
                 return result
-            logger.debug("[RedditLoader] Successfully extracted content from RSS fallback (%s chars)", len(result))
+            logger.info("[RedditLoader] Extracted content from RSS fallback (%s chars)", len(result))
             return result
         else:
-            logger.debug("[RedditLoader] Successfully extracted content from JSON endpoint (%s chars)", len(result))
+            logger.info("[RedditLoader] Extracted content from JSON endpoint (%s chars)", len(result))
             return result

--- a/src/kabigon/loaders/reel.py
+++ b/src/kabigon/loaders/reel.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 
 from kabigon.core.loader import Loader
@@ -7,6 +8,8 @@ from .httpx import HttpxLoader
 from .ytdlp import YtdlpLoader
 
 type LoaderFactory = Callable[[], Loader]
+
+logger = logging.getLogger(__name__)
 
 
 def check_reel_url(url: str) -> None:
@@ -23,9 +26,14 @@ class ReelLoader(Loader):
         self.httpx_loader_factory = httpx_loader_factory
 
     async def load(self, url: str) -> str:
+        logger.info("[ReelLoader] Processing URL: %s", url)
         parse_reel_target(url)
 
+        logger.info("[ReelLoader] Loading audio with YtdlpLoader")
         audio_content = await self.ytdlp_loader_factory().load(url)
+        logger.info("[ReelLoader] Loading HTML with HttpxLoader")
         html_content = await self.httpx_loader_factory().load(url)
 
-        return f"{audio_content}\n\n{html_content}"
+        result = f"{audio_content}\n\n{html_content}"
+        logger.info("[ReelLoader] Extracted combined reel content (%s chars)", len(result))
+        return result

--- a/src/kabigon/loaders/truthsocial.py
+++ b/src/kabigon/loaders/truthsocial.py
@@ -55,7 +55,7 @@ class TruthSocialLoader(Loader):
             LoaderNotApplicableError: If URL is not from Truth Social
             LoaderTimeoutError: If page loading times out
         """
-        logger.debug("[TruthSocialLoader] Processing URL: %s", url)
+        logger.info("[TruthSocialLoader] Processing URL: %s", url)
         parse_truthsocial_target(url)
 
         async def wait_for_post_content(page: Page) -> None:
@@ -76,8 +76,8 @@ class TruthSocialLoader(Loader):
             block_resource_types=DEFAULT_BLOCKED_RESOURCE_TYPES,
             after_goto=wait_for_post_content,
         )
-        logger.debug("[TruthSocialLoader] Page loaded successfully")
+        logger.debug("[TruthSocialLoader] Loaded browser page")
 
         result = html_to_markdown(content)
-        logger.debug("[TruthSocialLoader] Successfully extracted content (%s chars)", len(result))
+        logger.info("[TruthSocialLoader] Extracted Truth Social content (%s chars)", len(result))
         return result

--- a/src/kabigon/loaders/twitter.py
+++ b/src/kabigon/loaders/twitter.py
@@ -59,11 +59,11 @@ class TwitterLoader(Loader):
                     task.cancel()
 
     async def load(self, url: str) -> str:
-        logger.debug("[TwitterLoader] Processing URL: %s", url)
+        logger.info("[TwitterLoader] Processing URL: %s", url)
         parse_twitter_target(url)
 
         url = replace_domain(url)
-        logger.debug("[TwitterLoader] Normalized URL: %s", url)
+        logger.info("[TwitterLoader] Fetching normalized URL: %s", url)
 
         async def wait_for_tweet(page: Page) -> None:
             with contextlib.suppress(TimeoutError):
@@ -101,5 +101,5 @@ class TwitterLoader(Loader):
             extract_content=extract_tweet_content,
         )
         result = html_to_markdown(content)
-        logger.debug("[TwitterLoader] Successfully converted to markdown (%s chars)", len(result))
+        logger.info("[TwitterLoader] Extracted Twitter content (%s chars)", len(result))
         return result

--- a/src/kabigon/loaders/youtube.py
+++ b/src/kabigon/loaders/youtube.py
@@ -105,13 +105,14 @@ class YoutubeLoader(Loader):
         self.languages = languages or DEFAULT_LANGUAGES
 
     def load_sync(self, url: str) -> str:
-        logger.debug("[YoutubeLoader] Processing URL: %s", url)
+        logger.info("[YoutubeLoader] Processing URL: %s", url)
 
         video_id = require_loader_applicability("YoutubeLoader", url, parse_youtube_video_target).video_id
 
         logger.debug("[YoutubeLoader] Extracted video ID: %s", video_id)
 
         try:
+            logger.info("[YoutubeLoader] Fetching transcript")
             fetched = YouTubeTranscriptApi().fetch(video_id, self.languages)
         except Exception as e:
             logger.warning("[YoutubeLoader] Failed to fetch transcript for %s: %s", video_id, e)
@@ -135,7 +136,8 @@ class YoutubeLoader(Loader):
                 "YoutubeLoader", url, "Transcript is empty", "The video may not have any captions."
             )
 
-        logger.debug("[YoutubeLoader] Successfully extracted %s transcript lines", len(lines))
+        logger.info("[YoutubeLoader] Extracted transcript content (%s chars)", len(result))
+        logger.debug("[YoutubeLoader] Extracted %s transcript lines", len(lines))
         return result
 
     async def load(self, url: str) -> str:

--- a/src/kabigon/loaders/youtube_ytdlp.py
+++ b/src/kabigon/loaders/youtube_ytdlp.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections.abc import Callable
 
 from kabigon.core.loader import Loader
@@ -9,14 +10,20 @@ from .ytdlp import YtdlpLoader
 
 type LoaderFactory = Callable[[], Loader]
 
+logger = logging.getLogger(__name__)
+
 
 class YoutubeYtdlpLoader(Loader):
     def __init__(self, ytdlp_loader_factory: LoaderFactory = YtdlpLoader) -> None:
         self.ytdlp_loader_factory = ytdlp_loader_factory
 
     def load_sync(self, url: str) -> str:
+        logger.info("[YoutubeYtdlpLoader] Processing URL: %s", url)
         require_loader_applicability("YoutubeYtdlpLoader", url, parse_youtube_video_target)
-        return self.ytdlp_loader_factory().load_sync(url)
+        logger.info("[YoutubeYtdlpLoader] Loading YouTube audio transcript with YtdlpLoader")
+        result = self.ytdlp_loader_factory().load_sync(url)
+        logger.info("[YoutubeYtdlpLoader] Extracted transcript content (%s chars)", len(result))
+        return result
 
     async def load(self, url: str) -> str:
         return await asyncio.to_thread(self.load_sync, url)

--- a/src/kabigon/loaders/ytdlp.py
+++ b/src/kabigon/loaders/ytdlp.py
@@ -34,7 +34,8 @@ def download_audio(url: str, outtmpl: str | None = None) -> None:
     if ffmpeg_path is not None:
         ydl_opts["ffmpeg_location"] = ffmpeg_path
 
-    logger.info("Downloading audio from URL: %s with options: %s", url, ydl_opts)
+    logger.info("[YtdlpLoader] Downloading audio from URL: %s", url)
+    logger.debug("[YtdlpLoader] yt-dlp options: %s", ydl_opts)
     with yt_dlp.YoutubeDL(cast(Any, ydl_opts)) as ydl:
         ydl.download([url])
 
@@ -50,6 +51,7 @@ class YtdlpLoader(Loader):
         self.load_audio = whisper.load_audio
 
     def load_sync(self, url: str) -> str:
+        logger.info("[YtdlpLoader] Processing URL: %s", url)
         outtmpl = uuid.uuid4().hex[:20]
         path = str(Path(outtmpl).with_suffix(".mp3"))
         download_audio(url, outtmpl=outtmpl)
@@ -57,7 +59,8 @@ class YtdlpLoader(Loader):
 
         try:
             audio = self.load_audio(path)
-            logger.info("Transcribing audio file: %s", path)
+            logger.info("[YtdlpLoader] Transcribing audio file")
+            logger.debug("[YtdlpLoader] Audio file path: %s", path)
             result = self.model.transcribe(audio)
         finally:
             # Clean up the audio file
@@ -66,8 +69,11 @@ class YtdlpLoader(Loader):
 
         text = result.get("text", "")
         if isinstance(text, str):
+            logger.info("[YtdlpLoader] Extracted transcript content (%s chars)", len(text))
             return text
-        return "\n".join(str(item) for item in text)
+        joined_text = "\n".join(str(item) for item in text)
+        logger.info("[YtdlpLoader] Extracted transcript content (%s chars)", len(joined_text))
+        return joined_text
 
     async def load(self, url: str) -> str:
         return await asyncio.to_thread(self.load_sync, url)


### PR DESCRIPTION
## Summary
- Configure CLI logging at INFO by default, with `--verbose` enabling DEBUG output.
- Add loader-level INFO logs for important processing stages and output sizes.
- Keep detailed browser/content-type/internal diagnostics at DEBUG while preserving warnings for external failures.

## Verification
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run ty check .`
- `uv run pytest -v -s --cov=src tests`