### PR TITLE
feat: httpx default headers, faster playwright-fast, taiwan sites example

### DIFF
--- a/examples/taiwan_sites.py
+++ b/examples/taiwan_sites.py
@@ -1,0 +1,64 @@
+"""Batch-load a curated set of well-known Taiwanese websites.
+
+Demonstrates how kabigon's default loader chain handles a variety of Taiwan-
+focused content: news portals, forums, communities, and aggregators. Each URL
+is fetched concurrently via ``kabigon.load_url`` and the result is summarised
+(character count + first non-empty line as a sanity check).
+
+Run:
+    uv run python examples/taiwan_sites.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import kabigon
+
+TAIWAN_SITES: list[tuple[str, str]] = [
+    ("PTT 八卦版文章", "https://www.ptt.cc/bbs/Gossiping/M.1746078381.A.FFC.html"),
+    ("中央社 CNA", "https://www.cna.com.tw/"),
+    ("聯合新聞網 UDN", "https://udn.com/news/index"),
+    ("自由時報", "https://www.ltn.com.tw/"),
+    ("商業周刊", "https://www.businessweekly.com.tw/"),
+    ("Yahoo 奇摩", "https://tw.yahoo.com/"),
+    ("ETtoday", "https://www.ettoday.net/"),
+    ("巴哈姆特", "https://www.gamer.com.tw/"),
+]
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    name: str
+    url: str
+    ok: bool
+    detail: str
+
+
+async def _fetch(name: str, url: str) -> FetchResult:
+    try:
+        text = await kabigon.load_url(url)
+    except Exception as exc:  # noqa: BLE001 - surface any loader error
+        return FetchResult(name=name, url=url, ok=False, detail=f"{type(exc).__name__}: {exc}")
+
+    preview = next((line.strip() for line in text.splitlines() if line.strip()), "")
+    if len(preview) > 60:
+        preview = preview[:57] + "..."
+    return FetchResult(name=name, url=url, ok=True, detail=f"{len(text):>6} chars | {preview}")
+
+
+async def main() -> None:
+    print(f"Loading {len(TAIWAN_SITES)} Taiwanese sites in parallel...\n")
+    results = await asyncio.gather(*(_fetch(name, url) for name, url in TAIWAN_SITES))
+
+    for r in results:
+        marker = "✅" if r.ok else "❌"
+        print(f"{marker} {r.name:<16} {r.detail}")
+
+    ok_count = sum(1 for r in results if r.ok)
+    print(f"\nSummary: {ok_count}/{len(results)} succeeded.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/kabigon/loader_registry.py
+++ b/src/kabigon/loader_registry.py
@@ -61,7 +61,7 @@ LOADER_DEFS: tuple[LoaderDef, ...] = (
     LoaderDef(
         PLAYWRIGHT_FAST,
         "Browser-based scraping with faster defaults",
-        lambda: loaders.PlaywrightLoader(timeout=10_000),
+        lambda: loaders.PlaywrightLoader(timeout=15_000, wait_until="domcontentloaded"),
     ),
     LoaderDef(PLAYWRIGHT, "Browser-based scraping for any website", lambda: loaders.PlaywrightLoader()),
     LoaderDef(HTTPX, "Simple HTTP fetch + HTML to markdown", lambda: loaders.HttpxLoader()),

--- a/src/kabigon/loaders/httpx.py
+++ b/src/kabigon/loaders/httpx.py
@@ -9,10 +9,26 @@ from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_HTTPX_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+    ),
+    "Accept": ("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"),
+    "Accept-Language": "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7",
+}
+
+
+def _merge_headers(custom: dict[str, str] | None) -> dict[str, str]:
+    headers = dict(DEFAULT_HTTPX_HEADERS)
+    if custom:
+        headers.update(custom)
+    return headers
+
 
 class HttpxLoader(Loader):
     def __init__(self, headers: dict[str, str] | None = None) -> None:
-        self.headers = headers
+        self.headers = _merge_headers(headers)
 
     async def load(self, url: str) -> str:
         logger.info("[HttpxLoader] Processing URL: %s", url)


### PR DESCRIPTION
## Summary

- **httpx loader**: set default browser-like headers (User-Agent, Accept, Accept-Language) so plain HTTP fetches behave less like a bot. Custom headers still override defaults.
- **playwright-fast**: switch wait condition to `domcontentloaded` and bump timeout to 15s, trading "fully loaded" for responsiveness on heavy pages.
- **examples**: add `examples/taiwan_sites.py`, a batch loader sample over well-known Taiwanese sites (news, forums, communities) demonstrating concurrent `kabigon.load_url` usage.

## Affected URL/source cases

- Any site fetched via `HttpxLoader` (now sends realistic headers by default).
- Any site fetched via the `playwright-fast` registry entry.

## Notes

- No new dependencies.
- No behavior change for callers passing explicit `headers=` to `HttpxLoader` beyond gaining default fallbacks for unspecified keys.