### PR TITLE
fix(reddit): accept common URL variants

### DIFF
--- a/src/kabigon/loaders/reddit.py
+++ b/src/kabigon/loaders/reddit.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 from typing import cast
+from urllib.parse import ParseResult
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 from xml.etree import ElementTree as ET
@@ -18,6 +19,18 @@ from .utils import html_to_markdown
 
 logger = logging.getLogger(__name__)
 USER_AGENT = DEFAULT_BROWSER_USER_AGENT
+REDDIT_SHORT_HOSTS = {"redd.it", "www.redd.it"}
+
+
+def _reddit_endpoint_path(parsed: ParseResult) -> str:
+    path = parsed.path.rstrip("/")
+    if parsed.netloc.lower() not in REDDIT_SHORT_HOSTS:
+        return path
+
+    post_id = parsed.path.strip("/").split("/", maxsplit=1)[0]
+    if not post_id:
+        return path
+    return f"/comments/{post_id}"
 
 
 def check_reddit_url(url: str) -> None:
@@ -42,13 +55,14 @@ def convert_to_old_reddit(url: str) -> str:
         URL with old.reddit.com domain
     """
     parsed = urlparse(url)
-    return str(urlunparse(parsed._replace(netloc="old.reddit.com")))
+    path = _reddit_endpoint_path(parsed)
+    return str(urlunparse(parsed._replace(netloc="old.reddit.com", path=path, query="", fragment="")))
 
 
 def to_reddit_json_url(url: str) -> str:
     """Normalize Reddit URL to a `www.reddit.com/.../.json` API URL."""
     parsed = urlparse(url)
-    path = parsed.path.rstrip("/")
+    path = _reddit_endpoint_path(parsed)
     if not path.endswith(".json"):
         path = f"{path}.json"
     return str(urlunparse(parsed._replace(netloc="www.reddit.com", path=path, query="", fragment="")))
@@ -56,7 +70,7 @@ def to_reddit_json_url(url: str) -> str:
 
 def to_reddit_rss_url(url: str) -> str:
     parsed = urlparse(url)
-    path = parsed.path.rstrip("/")
+    path = _reddit_endpoint_path(parsed)
     if not path.endswith(".rss"):
         path = f"{path}/.rss"
     return str(urlunparse(parsed._replace(netloc="www.reddit.com", path=path, query="", fragment="")))

--- a/src/kabigon/sources/applicability.py
+++ b/src/kabigon/sources/applicability.py
@@ -44,6 +44,12 @@ REDDIT_DOMAINS = (
     "reddit.com",
     "www.reddit.com",
     "old.reddit.com",
+    "new.reddit.com",
+    "np.reddit.com",
+    "m.reddit.com",
+    "sh.reddit.com",
+    "redd.it",
+    "www.redd.it",
 )
 REEL_PREFIX = "https://www.instagram.com/reel"
 TRUTHSOCIAL_DOMAINS = (

--- a/tests/loaders/test_reddit.py
+++ b/tests/loaders/test_reddit.py
@@ -5,6 +5,7 @@ import pytest
 
 from kabigon.loaders import reddit
 from kabigon.loaders.reddit import RedditLoader
+from kabigon.loaders.reddit import convert_to_old_reddit
 from kabigon.loaders.reddit import to_reddit_json_url
 from kabigon.loaders.reddit import to_reddit_rss_url
 
@@ -63,6 +64,13 @@ def test_to_reddit_json_url_normalizes_host_and_path() -> None:
 def test_to_reddit_rss_url_normalizes_host_and_path() -> None:
     url = "https://old.reddit.com/r/selfhosted/comments/abc123/example/?utm_source=share"
     assert to_reddit_rss_url(url) == "https://www.reddit.com/r/selfhosted/comments/abc123/example/.rss"
+
+
+def test_reddit_short_url_normalizes_to_comments_path() -> None:
+    url = "https://redd.it/abc123?utm_source=share"
+    assert to_reddit_json_url(url) == "https://www.reddit.com/comments/abc123.json"
+    assert to_reddit_rss_url(url) == "https://www.reddit.com/comments/abc123/.rss"
+    assert convert_to_old_reddit(url) == "https://old.reddit.com/comments/abc123"
 
 
 def test_reddit_loader_prefers_json_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/sources/test_applicability.py
+++ b/tests/sources/test_applicability.py
@@ -63,6 +63,20 @@ def test_source_applicability_rejects_unknown_targets(is_applicable) -> None:
     assert not is_applicable("https://example.com/not-supported")
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://new.reddit.com/r/python/comments/abc/example/",
+        "https://np.reddit.com/r/python/comments/abc/example/",
+        "https://m.reddit.com/r/python/comments/abc/example/",
+        "https://sh.reddit.com/r/python/comments/abc/example/",
+        "https://redd.it/abc",
+    ],
+)
+def test_reddit_applicability_accepts_common_url_variants(url: str) -> None:
+    assert is_reddit_url(url)
+
+
 def test_youtube_applicability_rejects_playlist() -> None:
     assert not is_youtube_video_url("https://www.youtube.com/playlist?list=PL123")
 


### PR DESCRIPTION
## Summary
- accept common Reddit hosts such as new.reddit.com, m.reddit.com, np.reddit.com, sh.reddit.com, and redd.it
- normalize redd.it short links to /comments/<id> for Reddit JSON/RSS/old Reddit fallback paths
- add tests for Reddit URL variant applicability and short-link normalization

## Verification
- uv run ruff check .
- uv run ty check .
- uv run pytest -q
- uv run kabigon https://new.reddit.com/r/SonyAlpha/comments/1f9xt2k/regrets_upgrading_to_a7cii/
- uv run kabigon https://redd.it/1f9xt2k