### PR TITLE
fix(reddit): prefer RSS endpoint

### DIFF
--- a/src/kabigon/loaders/reddit.py
+++ b/src/kabigon/loaders/reddit.py
@@ -195,7 +195,7 @@ def _rss_to_markdown(xml_text: str, source_url: str) -> str:
 class RedditLoader(Loader):
     """Loader for Reddit posts and comments.
 
-    Uses old.reddit.com for better content extraction without CAPTCHA.
+    Prefers Reddit's Atom/RSS feed, then falls back to JSON and old.reddit.com browser extraction.
     """
 
     def __init__(self, timeout: float = 30_000) -> None:
@@ -250,7 +250,7 @@ class RedditLoader(Loader):
         rss_url = to_reddit_rss_url(url)
         timeout_seconds = self.timeout / 1000
         try:
-            logger.info("[RedditLoader] Fetching Reddit RSS fallback")
+            logger.info("[RedditLoader] Fetching Reddit RSS endpoint")
             logger.debug("[RedditLoader] Reddit RSS URL: %s", rss_url)
             async with httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=True) as client:
                 response = await client.get(rss_url)
@@ -304,21 +304,21 @@ class RedditLoader(Loader):
         logger.info("[RedditLoader] Processing URL: %s", url)
         parse_reddit_target(url)
         try:
-            result = await self._load_via_json(url)
-        except (LoaderContentError, LoaderTimeoutError) as json_error:
-            logger.warning("[RedditLoader] JSON endpoint failed, trying RSS fallback: %s", json_error)
+            result = await self._load_via_rss(url)
+        except (LoaderContentError, LoaderTimeoutError) as rss_error:
+            logger.warning("[RedditLoader] RSS endpoint failed, trying JSON fallback: %s", rss_error)
             try:
-                result = await self._load_via_rss(url)
-            except (LoaderContentError, LoaderTimeoutError) as rss_error:
-                logger.warning("[RedditLoader] RSS fallback failed, falling back to old Reddit: %s", rss_error)
+                result = await self._load_via_json(url)
+            except (LoaderContentError, LoaderTimeoutError) as json_error:
+                logger.warning("[RedditLoader] JSON fallback failed, falling back to old Reddit: %s", json_error)
                 result = await self._load_via_old_reddit(url)
                 logger.info(
                     "[RedditLoader] Extracted content from old Reddit fallback (%s chars)",
                     len(result),
                 )
                 return result
-            logger.info("[RedditLoader] Extracted content from RSS fallback (%s chars)", len(result))
+            logger.info("[RedditLoader] Extracted content from JSON fallback (%s chars)", len(result))
             return result
         else:
-            logger.info("[RedditLoader] Extracted content from JSON endpoint (%s chars)", len(result))
+            logger.info("[RedditLoader] Extracted content from RSS endpoint (%s chars)", len(result))
             return result

--- a/tests/loaders/test_reddit.py
+++ b/tests/loaders/test_reddit.py
@@ -21,39 +21,106 @@ RSS_XML = """
 </feed>
 """.strip()
 
+JSON_PAYLOAD = [
+    {
+        "data": {
+            "children": [
+                {
+                    "data": {
+                        "title": "Nomad selfhosted trip planner",
+                        "author": "alice",
+                        "subreddit": "selfhosted",
+                        "score": 123,
+                        "permalink": "/r/selfhosted/comments/abc123/example/",
+                        "selftext": "Great project",
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "data": {
+            "children": [
+                {"kind": "t1", "data": {"author": "bob", "score": 7, "body": "Looks useful!"}},
+            ]
+        }
+    },
+]
 
-class Json403ThenRssResponse:
-    def __init__(self, url: str) -> None:
+
+class RedditResponse:
+    def __init__(self, url: str, *, status_code: int = 200, payload: object = JSON_PAYLOAD) -> None:
         self._url = url
+        self._status_code = status_code
+        self._payload = payload
         self.text = RSS_XML
 
     def raise_for_status(self) -> None:
-        if self._url.endswith(".json"):
+        if self._status_code >= 400:
             raise httpx.HTTPStatusError(
-                "forbidden",
-                request=httpx.Request("GET", "https://www.reddit.com"),
-                response=httpx.Response(403),
+                f"HTTP {self._status_code}",
+                request=httpx.Request("GET", self._url),
+                response=httpx.Response(self._status_code),
             )
 
     def json(self) -> object:
-        raise AssertionError("json() should not be called")
+        return self._payload
 
 
-class Json403ThenRssClient:
+class RssOnlyClient:
     def __init__(self, **_: object) -> None:
         return None
 
-    async def __aenter__(self) -> "Json403ThenRssClient":
+    async def __aenter__(self) -> "RssOnlyClient":
         return self
 
-    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+    async def __aexit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
         return None
 
-    async def get(self, url: str, headers: dict[str, str] | None = None) -> Json403ThenRssResponse:
+    async def get(self, url: str, headers: dict[str, str] | None = None) -> RedditResponse:
+        assert url == "https://www.reddit.com/r/python/comments/abc/demo/.rss"
+        assert headers is None
+        return RedditResponse(url)
+
+
+class Rss403ThenJsonClient:
+    def __init__(self, **_: object) -> None:
+        return None
+
+    async def __aenter__(self) -> "Rss403ThenJsonClient":
+        return self
+
+    async def __aexit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        return None
+
+    async def get(self, url: str, headers: dict[str, str] | None = None) -> RedditResponse:
+        if url.endswith("/.rss"):
+            assert headers is None
+            return RedditResponse(url, status_code=403)
         if url.endswith(".json"):
             assert headers is not None
             assert headers["Accept"] == "application/json"
-        return Json403ThenRssResponse(url)
+            return RedditResponse(url)
+        raise AssertionError(f"unexpected URL: {url}")
+
+
+class RssAndJson403Client:
+    def __init__(self, **_: object) -> None:
+        return None
+
+    async def __aenter__(self) -> "RssAndJson403Client":
+        return self
+
+    async def __aexit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        return None
+
+    async def get(self, url: str, headers: dict[str, str] | None = None) -> RedditResponse:
+        if url.endswith(".json"):
+            assert headers is not None
+            assert headers["Accept"] == "application/json"
+        else:
+            assert headers is None
+        return RedditResponse(url, status_code=403)
 
 
 def test_to_reddit_json_url_normalizes_host_and_path() -> None:
@@ -73,57 +140,24 @@ def test_reddit_short_url_normalizes_to_comments_path() -> None:
     assert convert_to_old_reddit(url) == "https://old.reddit.com/comments/abc123"
 
 
-def test_reddit_loader_prefers_json_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
-    class FakeResponse:
-        def raise_for_status(self) -> None:
-            return None
-
-        def json(self) -> object:
-            return [
-                {
-                    "data": {
-                        "children": [
-                            {
-                                "data": {
-                                    "title": "Nomad selfhosted trip planner",
-                                    "author": "alice",
-                                    "subreddit": "selfhosted",
-                                    "score": 123,
-                                    "permalink": "/r/selfhosted/comments/abc123/example/",
-                                    "selftext": "Great project",
-                                }
-                            }
-                        ]
-                    }
-                },
-                {
-                    "data": {
-                        "children": [
-                            {"kind": "t1", "data": {"author": "bob", "score": 7, "body": "Looks useful!"}},
-                        ]
-                    }
-                },
-            ]
-
-    class FakeClient:
-        def __init__(self, **_: object) -> None:
-            return None
-
-        async def __aenter__(self) -> "FakeClient":
-            return self
-
-        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-            return None
-
-        async def get(self, url: str, headers: dict[str, str]) -> FakeResponse:
-            assert url == "https://www.reddit.com/r/selfhosted/comments/abc123/example.json"
-            assert headers["Accept"] == "application/json"
-            return FakeResponse()
-
-    async def fail_fallback(self: RedditLoader, url: str) -> str:
+def test_reddit_loader_prefers_rss_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_fallback(_self: RedditLoader, url: str) -> str:
         raise AssertionError(f"fallback should not be called: {url}")
 
-    monkeypatch.setattr(reddit.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(reddit.httpx, "AsyncClient", RssOnlyClient)
+    monkeypatch.setattr(RedditLoader, "_load_via_old_reddit", fail_fallback)
+
+    result = asyncio.run(RedditLoader().load("https://www.reddit.com/r/python/comments/abc/demo/"))
+    assert "Demo Feed" in result
+    assert "Post title" in result
+    assert "RSS content" in result
+
+
+def test_reddit_loader_falls_back_to_json_when_rss_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_fallback(_self: RedditLoader, url: str) -> str:
+        raise AssertionError(f"fallback should not be called: {url}")
+
+    monkeypatch.setattr(reddit.httpx, "AsyncClient", Rss403ThenJsonClient)
     monkeypatch.setattr(RedditLoader, "_load_via_old_reddit", fail_fallback)
 
     result = asyncio.run(
@@ -135,14 +169,12 @@ def test_reddit_loader_prefers_json_endpoint(monkeypatch: pytest.MonkeyPatch) ->
     assert "Looks useful!" in result
 
 
-def test_reddit_loader_falls_back_when_json_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_fallback(self: RedditLoader, url: str) -> str:
+def test_reddit_loader_uses_old_reddit_when_rss_and_json_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fallback(_self: RedditLoader, url: str) -> str:
         return f"fallback:{url}"
 
-    monkeypatch.setattr(reddit.httpx, "AsyncClient", Json403ThenRssClient)
+    monkeypatch.setattr(reddit.httpx, "AsyncClient", RssAndJson403Client)
     monkeypatch.setattr(RedditLoader, "_load_via_old_reddit", fake_fallback)
 
     result = asyncio.run(RedditLoader().load("https://www.reddit.com/r/python/comments/abc/demo/"))
-    assert "Demo Feed" in result
-    assert "Post title" in result
-    assert "RSS content" in result
+    assert result == "fallback:https://www.reddit.com/r/python/comments/abc/demo/"


### PR DESCRIPTION
## Summary
- Prefer Reddit RSS/Atom feeds before JSON to avoid JSON 403 blocks.
- Keep JSON and old.reddit browser extraction as fallbacks.
- Update Reddit loader tests for RSS-first, JSON fallback, and old.reddit fallback behavior.

## Tests
- uv run ruff check .
- uv run ty check .
- uv run pytest -q
- uv run kabigon 'https://old.reddit.com/r/SonyAlpha/comments/14ocgdr/reliable_geotagging_for_sony_cameras_is_here/'